### PR TITLE
Make encrypted chunk size 8 mb + 32bytes to fit the multipart upload by AWS. The plan data chunks are now splitted by 8Mb. 

### DIFF
--- a/README-developer.md
+++ b/README-developer.md
@@ -1,4 +1,4 @@
-# AltaStata Python Package Developer Guide
+# AltaStata Python Package Developer Guide v0.1.10
 
 ## Prerequisites
 
@@ -48,6 +48,21 @@ pip install altastata
 
 # Run tests
 python test_script.py
+
+## Build and Upload
+
+Use the comprehensive build script for easy deployment:
+
+```bash
+# Complete build and upload process
+./build-and-upload.sh
+
+# Or run individual steps:
+python -m build                    # Build Python package
+twine upload dist/*               # Upload to PyPI
+./build-all-images.sh             # Build Docker images
+./push-to-ghcr.sh                # Push to GHCR
+```
 ```## Docker Deployment
 
 ### Building the Image

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-from altastata.altastata_tensorflow_dataset import register_altastata_functions_for_tensorflowfrom altastata.altastata_pytorch_dataset import register_altastata_functions_for_pytorch
-
-# Altastata Python Package
+# Altastata Python Package v0.1.10
 
 A powerful Python package for data processing and machine learning integration with Altastata.
 
@@ -14,13 +12,16 @@ pip install altastata
 
 - Seamless integration with PyTorch and TensorFlow
 - Advanced data processing capabilities
-- Java integration through Py4J
+- Java integration through Py4J with optimized memory management
 - Support for large-scale data operations
+- Improved garbage collection and memory optimization
 
 ## Quick Start
 
 ```python
 from altastata import AltaStataFunctions, AltaStataPyTorchDataset, AltaStataTensorFlowDataset
+from altastata.altastata_tensorflow_dataset import register_altastata_functions_for_tensorflow
+from altastata.altastata_pytorch_dataset import register_altastata_functions_for_pytorch
 
 # Configuration parameters
 user_properties = """#My Properties
@@ -45,11 +46,11 @@ wV5BUmp5CEmbeB4r/+BlFttRZBLBXT1sq80YyQIVLumq0Livao9mOg==
 altastata_functions = AltaStataFunctions.from_credentials(user_properties, private_key)
 altastata_functions.set_password("my_password")
 
-# register the altastata functions for PyTorch or TensorFlow as a custom dataset
+# Register the altastata functions for PyTorch or TensorFlow as a custom dataset
 register_altastata_functions_for_pytorch(altastata_functions, "bob123_rsa")
 register_altastata_functions_for_tensorflow(altastata_functions, "bob123_rsa")
 
-# for PyTorch application use
+# For PyTorch application use
 torch_dataset = AltaStataPyTorchDataset(
     "bob123_rsa",
     root_dir=root_dir,
@@ -57,7 +58,7 @@ torch_dataset = AltaStataPyTorchDataset(
     transform=transform
 )
 
-# for tensorflow application use
+# For TensorFlow application use
 tensorflow_dataset = AltaStataTensorFlowDataset(
     "bob123_rsa",  # Using AltaStata account for testing
     root_dir=root_dir,

--- a/altastata/__init__.py
+++ b/altastata/__init__.py
@@ -3,7 +3,7 @@ AltaStata Python Package
 A powerful Python package for data processing and machine learning integration with Altastata.
 """
 
-__version__ = "0.1.7"
+__version__ = "0.1.11"
 
 from .altastata_functions import AltaStataFunctions
 from .altastata_pytorch_dataset import AltaStataPyTorchDataset

--- a/altastata/base_gateway.py
+++ b/altastata/base_gateway.py
@@ -48,6 +48,14 @@ class BaseGateway:
         java_command = [
             'java',
             '--add-opens', 'java.base/java.util=ALL-UNNAMED',
+            '-Xms1g',                    # Initial heap size
+            '-Xmx4g',                    # Max heap size
+            '-XX:+UseZGC',               # Use ZGC for very low pause times
+            '-XX:+UnlockExperimentalVMOptions',
+            '-XX:+UseStringDeduplication', # Reduce memory usage for strings
+            '-Xlog:gc*:file=gc.log:time,uptime:filecount=5,filesize=10M', # GC logging
+            '-XX:ThreadStackSize=256k',  # Reduce thread stack size
+            '-XX:+DisableExplicitGC',    # Prevent explicit GC calls
             '-cp', classpath,
             'py4j.GatewayServer'
         ]

--- a/build-and-upload.sh
+++ b/build-and-upload.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# AltaStata Python Package - Complete Build and Upload Script
+# This script builds the Python package and Docker images, then uploads them
+
+set -e  # Exit on any error
+
+echo "🚀 Starting AltaStata Python Package build and upload process..."
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check prerequisites
+print_status "Checking prerequisites..."
+
+# Check if required tools are installed
+if ! command -v python &> /dev/null; then
+    print_error "Python is not installed or not in PATH"
+    exit 1
+fi
+
+if ! command -v docker &> /dev/null; then
+    print_error "Docker is not installed or not in PATH"
+    exit 1
+fi
+
+if ! command -v twine &> /dev/null; then
+    print_warning "twine not found, installing..."
+    pip install --upgrade twine
+fi
+
+# Check for PyPI credentials
+if [ ! -f ~/.pypirc ]; then
+    print_warning "PyPI credentials not found (~/.pypirc)"
+    print_warning "You may need to configure PyPI upload manually"
+fi
+
+# Check for GitHub token
+if [ -z "$GITHUB_TOKEN" ]; then
+    print_warning "GITHUB_TOKEN environment variable not set"
+    print_warning "Docker images will be built but not pushed to GHCR"
+fi
+
+# Step 1: Build Python Package
+print_status "Step 1: Building Python package..."
+
+# Clean previous builds
+print_status "Cleaning previous builds..."
+rm -rf dist/ build/ *.egg-info/ 2>/dev/null || true
+
+# Build the package
+print_status "Building package with python -m build..."
+python -m build
+
+# Verify the built package
+print_status "Verifying built package..."
+twine check dist/*
+
+print_success "Python package built successfully!"
+
+# Step 2: Upload Python Package to PyPI
+read -p "Do you want to upload the Python package to PyPI? (y/N): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    print_status "Step 2: Uploading Python package to PyPI..."
+    twine upload dist/*
+    print_success "Python package uploaded to PyPI!"
+else
+    print_warning "Skipping PyPI upload"
+fi
+
+# Step 3: Build Docker Images
+print_status "Step 3: Building Docker images..."
+./build-all-images.sh
+
+# Step 4: Push Docker Images to GHCR
+if [ -n "$GITHUB_TOKEN" ]; then
+    read -p "Do you want to push Docker images to GHCR? (y/N): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        print_status "Step 4: Pushing Docker images to GHCR..."
+        ./push-to-ghcr.sh
+        print_success "Docker images pushed to GHCR!"
+    else
+        print_warning "Skipping GHCR push"
+    fi
+else
+    print_warning "GITHUB_TOKEN not set, skipping GHCR push"
+fi
+
+print_success "Build and upload process completed!"
+echo ""
+echo "📦 Summary:"
+echo "- Python package: Built and optionally uploaded to PyPI"
+echo "- Docker images: Built for AMD64 and ARM64 architectures"
+echo "- Docker images: Optionally pushed to GHCR"
+echo ""
+echo "🔧 Next steps:"
+echo "- Test the uploaded package: pip install altastata"
+echo "- Test Docker images: docker-compose up -d"
+echo "- Update version in setup.py for next release" 

--- a/docker-compose-ghcr.yml
+++ b/docker-compose-ghcr.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   altastata-jupyter:
-    image: ghcr.io/sergevil/altastata/jupyter-datascience:latest
+    image: ghcr.io/sergevil/altastata/jupyter-datascience-arm64:latest
     container_name: altastata-jupyter
     ports:
       - "8888:8888"

--- a/push-to-ghcr.sh
+++ b/push-to-ghcr.sh
@@ -28,12 +28,16 @@ echo "Pushing jupyter-datascience-arm64 images..."
 docker push ghcr.io/sergevil/altastata/jupyter-datascience-arm64:latest
 docker push ghcr.io/sergevil/altastata/jupyter-datascience-arm64:2025a_latest
 
-# Create legacy tag by tagging the AMD64 image
+# Create legacy tags by tagging the AMD64 image
+echo "Creating legacy tag jupyter-datascience:latest linked to AMD64 image..."
+docker tag ghcr.io/sergevil/altastata/jupyter-datascience-amd64:latest ghcr.io/sergevil/altastata/jupyter-datascience:latest
+
 echo "Creating legacy tag jupyter-datascience:2025a_latest linked to AMD64 image..."
 docker tag ghcr.io/sergevil/altastata/jupyter-datascience-amd64:2025a_latest ghcr.io/sergevil/altastata/jupyter-datascience:2025a_latest
 
-# Push the legacy tag
-echo "Pushing legacy tag to GHCR..."
+# Push the legacy tags
+echo "Pushing legacy tags to GHCR..."
+docker push ghcr.io/sergevil/altastata/jupyter-datascience:latest
 docker push ghcr.io/sergevil/altastata/jupyter-datascience:2025a_latest
 
 echo ""

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='altastata',
-    version='0.1.8',
+    version='0.1.11',
     author='Serge Vilvovsky',
     author_email='serge.vilvovsky@altastata.com',
     description='A Python package for Altastata data processing and machine learning integration',


### PR DESCRIPTION
Make static OpsExecutors.ecCloudObjectUploadOps and OpsExecutors.ecCloudObjectDownloadOps instead of ExecutionContext per cloud type