### PR TITLE
LinuxONE s390x RAG/Jupyter, version tags, GHCR ergonomics, zDNN gating

### DIFF
--- a/.cursor/rules/git-workflow-assistants.mdc
+++ b/.cursor/rules/git-workflow-assistants.mdc
@@ -1,0 +1,11 @@
+---
+description: Do not git commit or push unless the user explicitly asks (mirrors CLAUDE.md).
+alwaysApply: true
+---
+
+# Git workflow (AI assistants)
+
+- Do **not** run `git commit` unless the user **explicitly** asks you to commit. Make code or doc edits as requested; leave commits to the user unless they say otherwise.
+- Do **not** `git push` branch updates to a remote unless the user **explicitly** asks. (Pushing Docker images to a registry is separate.)
+
+This mirrors `CLAUDE.md` — keep both in sync if you edit one.

--- a/.cursor/rules/linuxone-deployment.mdc
+++ b/.cursor/rules/linuxone-deployment.mdc
@@ -1,0 +1,12 @@
+---
+description: LinuxONE / s390x — rsync sync, build images ON VM, run as containers (no bare python deploy).
+alwaysApply: true
+---
+
+# LinuxONE (s390x)
+
+- **Canonical flow:** Refresh tree (**`rsync` from Mac**, not `git` on VM unless you choose it) → **build Docker images on LinuxONE** (`containers/linuxone/build-jupyter-and-rag-on-linuxone.sh`) → **run Jupyter + RAG as `docker` containers** (e.g. `containers/linuxone/run-jupyter-and-rag-on-server-for-browser.sh` or manual `docker run`). Use containers for JDK + PyTorch/llama.cpp + layout—not ad-hoc venv installs on bare metal for deployments.
+- **Mac orchestration:** `containers/build-s390x-jupyter-and-rag-on-server.sh` (**workstation-only**) rsync+s then invokes the **`linuxone/`** builder on the server.
+- **`containers/linuxone/*.sh`** expect a **directory tree already on the VM** (copied/rsync'd).
+
+See **`CLAUDE.md`** (RAG Open LLM on IBM Z) for the mirrored detail.

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,7 @@ examples/rag-example/open_llm/chroma_data/
 # RAG s390x: self-converted F16 BE GGUF staged into the docker build context
 # by build-rag-s390x-on-server.sh. ~2.5 GB, never commit.
 containers/rag-example/llama-3.2-1b-instruct-be.f16.gguf
+
+# Local RAG dev: account props and Mac-side build transcripts (never commit)
+containers/rag-example/*.user.properties
+rag-zdnn-build.log

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ setup_output*.log
 # RAG open_llm: generated index and chroma (do not ship in image or commit)
 examples/rag-example/open_llm/local_index/
 examples/rag-example/open_llm/chroma_data/
+
+# RAG s390x: self-converted F16 BE GGUF staged into the docker build context
+# by build-rag-s390x-on-server.sh. ~2.5 GB, never commit.
+containers/rag-example/llama-3.2-1b-instruct-be.f16.gguf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Git workflow (AI assistants)
+
+- Do **not** run `git commit` unless the user **explicitly** asks you to commit. Make code or doc edits as requested; leave commits to the user unless they say otherwise.
+- Do **not** `git push` branch updates to a remote unless the user **explicitly** asks. (Pushing Docker images to a registry is separate.)
+- Cursor: the same wording lives in `.cursor/rules/git-workflow-assistants.mdc` (**alwaysApply**); keep them in sync if you change either.
+
 ## Project Overview
 
 This is the Altastata Python package - a library for cloud-based data processing with machine learning integration. The package provides seamless integration with PyTorch and TensorFlow through custom datasets that can handle data from both local filesystems and AltaStata cloud storage.
@@ -58,8 +64,11 @@ docker run -d -p 8888:8888 \
 ```
 
 ### RAG Open LLM on IBM Z (s390x)
-- **Build on server:** `./containers/rag-example/build-rag-s390x-on-server.sh` (syncs repo, builds image on LinuxONE; set `SSH_HOST`, `SSH_KEY` if needed).
-- **Push to ICR:** `./containers/rag-example/push-rag-s390x-to-icr-from-server.sh` (after build). **Run:** `./containers/rag-example/pull-and-run-rag-s390x-from-icr.sh`.
+- **Canonical flow on LinuxONE:** (1) sync repo tree onto the VM (usually **`rsync` from Mac**—no `git` required on VM), (2) **build Jupyter + RAG Docker images ON LinuxONE**, (3) **run Jupyter and RAG as containers** (`docker run` / `containers/linuxone/run-jupyter-and-rag-on-server-for-browser.sh`). Do **not** run Jupyter or RAG as bare `python` on Z for deployment—containers carry the JDK, PyTorch/llama.cpp stack, and layout. Optionally push validated images to ICR.
+- **LinuxONE VM:** Assume **no `git` on the server**. Refreshes are typically **`rsync` from Mac** into `REMOTE_DIR` (see `build-rag-s390x-on-server.sh`, `build-jupyter-s390x-on-server.sh`, `containers/build-s390x-jupyter-and-rag-on-server.sh`). On the VM you only need a **synced directory tree** plus Docker. **Build on VM:** `./containers/linuxone/build-jupyter-and-rag-on-linuxone.sh`. Cursor: `.cursor/rules/linuxone-deployment.mdc` (**alwaysApply**).
+- **Orchestration from Mac (optional):** `containers/build-s390x-jupyter-and-rag-on-server.sh` rsync+s then invokes the **`linuxone/`** runner on the server (detached builds). Do **not** run that orchestration script *on* the VM.
+- **Build one image via Mac SSH:** `./containers/rag-example/build-rag-s390x-on-server.sh`; `./containers/jupyter/build-jupyter-s390x-on-server.sh`.
+- **Push to ICR:** `./containers/rag-example/push-rag-s390x-to-icr-from-server.sh` / `./containers/jupyter/push-jupyter-s390x-to-icr-from-server.sh` (after builds). Pull prebuilt images and run containers: `./containers/rag-example/pull-and-run-rag-s390x-from-icr.sh`.
 - **Image:** `containers/rag-example/Dockerfile.open_llm_s390x` (base: ibmz-accelerated-for-pytorch; deps layer cached when requirements.txt unchanged). See `examples/rag-example/open_llm/README.md` for full s390x docs.
 
 ### RAG Open LLM on Mac (same layout as s390x)

--- a/altastata/__init__.py
+++ b/altastata/__init__.py
@@ -5,9 +5,9 @@ A powerful Python package for data processing and machine learning integration w
 
 # Derive __version__ from the installed package metadata (set by setup.py at
 # build time), so we have a single source of truth and never need to bump it
-# in two places. Previously hardcoded as "0.1.21" and silently drifted from
-# the real PyPI version (0.1.27 at this commit). importlib.metadata is stdlib
-# since Python 3.8.
+# in two places. Previously hardcoded as a literal here and silently drifted
+# from the real PyPI version across many releases. importlib.metadata is
+# stdlib since Python 3.8.
 from importlib.metadata import version as _pkg_version, PackageNotFoundError as _PkgNotFound
 
 try:

--- a/altastata/__init__.py
+++ b/altastata/__init__.py
@@ -3,7 +3,19 @@ AltaStata Python Package
 A powerful Python package for data processing and machine learning integration with Altastata.
 """
 
-__version__ = "0.1.21"
+# Derive __version__ from the installed package metadata (set by setup.py at
+# build time), so we have a single source of truth and never need to bump it
+# in two places. Previously hardcoded as "0.1.21" and silently drifted from
+# the real PyPI version (0.1.27 at this commit). importlib.metadata is stdlib
+# since Python 3.8.
+from importlib.metadata import version as _pkg_version, PackageNotFoundError as _PkgNotFound
+
+try:
+    __version__ = _pkg_version("altastata")
+except _PkgNotFound:
+    # Importing from a source checkout without `pip install -e .` (or the
+    # package was renamed at install time) — fall back rather than crash.
+    __version__ = "0.0.0+unknown"
 
 from .altastata_functions import AltaStataFunctions
 

--- a/containers/build-s390x-jupyter-and-rag-on-server.sh
+++ b/containers/build-s390x-jupyter-and-rag-on-server.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Workstation/Mac only — rsync + SSH orchestration. Do NOT run this script ON LinuxONE.
+# On IBM Z/LinuxONE VM (after your tree is in place): only
+#   ./containers/linuxone/build-jupyter-and-rag-on-linuxone.sh
+#
 # Sync repo (+ accounts blob) from your Mac to LinuxONE, then start Jupyter+RAG s390x
 # Docker builds *on LinuxONE*.
 #
@@ -16,6 +20,14 @@
 #   ENABLE_ZDNN=1 SSH_HOST=... REMOTE_BUILD_LOG=/tmp/foo.log DETACHED=0 ...
 #
 set -euo pipefail
+
+if [ "${SKIP_S390X_WORKSTATION_CHECK:-}" != "1" ] && command -v uname >/dev/null 2>&1 && [ "$(uname -m)" = "s390x" ]; then
+    echo "$(basename "$0"): this script orchestrates SSH/rsync FROM a workstation; you are ON s390x." >&2
+    echo "On LinuxONE, from repo root run only:" >&2
+    echo "  ./containers/linuxone/build-jupyter-and-rag-on-linuxone.sh" >&2
+    echo "(Override: SKIP_S390X_WORKSTATION_CHECK=1)" >&2
+    exit 2
+fi
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SSH_KEY="${SSH_KEY:-/Users/sergevilvovsky/Downloads/torontolinuxonesshkey_rsa.prv}"
@@ -122,6 +134,7 @@ EOS
 fi
 
 echo ""
-echo "When builds finish, images/tags follow version.sh (JUPYTER_VERSION, RAG_VERSION)."
+echo "When builds finish (see log), run Jupyter + RAG for browser testing before ICR push:"
+echo "  ./containers/linuxone/run-jupyter-and-rag-on-server-for-browser.sh"
 echo "Push Jupyter: ./containers/jupyter/push-jupyter-s390x-to-icr-from-server.sh"
 echo "Push RAG:     ICR_TOKEN=... ./containers/rag-example/push-rag-s390x-to-icr-from-server.sh"

--- a/containers/build-s390x-jupyter-and-rag-on-server.sh
+++ b/containers/build-s390x-jupyter-and-rag-on-server.sh
@@ -1,21 +1,20 @@
 #!/usr/bin/env bash
-# Optional: run from your Mac to rsync the repo to LinuxONE then start parallel
-# Docker builds *on the server* (still no Docker on Mac — only rsync + ssh).
+# Sync repo (+ accounts blob) from your Mac to LinuxONE, then start Jupyter+RAG s390x
+# Docker builds *on LinuxONE*.
 #
-# Prefer running everything on LinuxONE (no Mac workflows):
-#   ssh … "cd /path/to/altastata-python-package && git pull && ./containers/linuxone/build-jupyter-and-rag-in-parallel.sh"
+# **Default DETACHED=1:** starts builds under nohup and returns immediately so your Mac is
+# not tied to a hours-long SSH session — work on the Mac in parallel with builds on IBM Z.
 #
-# This script: one rsync prep, then Jupyter + RAG s390x builds IN PARALLEL on LinuxONE.
-# Avoids invoking build-jupyter + build-rag scripts together (their concurrent
-# rsync --delete races the same REMOTE_DIR and can corrupt context).
+# Blocking (stream logs until done): DETACHED=0 ./containers/build-s390x-jupyter-and-rag-on-server.sh
+#
+# Pure LinuxONE (no rsync): after git pull, run
+#   ./containers/linuxone/build-jupyter-and-rag-on-linuxone.sh
 #
 # Run from repo root:
-#   ./containers/build-s390x-jupyter-and-rag-parallel-on-server.sh
-# Optional same as rag script:
-#   ENABLE_ZDNN=1 SSH_HOST=...
+#   ./containers/build-s390x-jupyter-and-rag-on-server.sh
+# Optional:
+#   ENABLE_ZDNN=1 SSH_HOST=... REMOTE_BUILD_LOG=/tmp/foo.log DETACHED=0 ...
 #
-# Prerequisites: SSH to server, Docker on server, same REMOTE_DIR default as sibling scripts.
-
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -27,12 +26,13 @@ REMOTE_ALTASTATA_ACCOUNTS="${REMOTE_ALTASTATA_ACCOUNTS:-/root/.altastata/account
 REMOTE_HPCS_DIR="${REMOTE_HPCS_DIR:-/home/jovyan/hpcs}"
 ALTASTATA_ACCOUNTS="${ALTASTATA_ACCOUNTS:-$HOME/.altastata/accounts/amazon.rsa.bob123 $HOME/.altastata/accounts/amazon.rsa.hpcs.serge678}"
 ENABLE_ZDNN="${ENABLE_ZDNN:-0}"
+DETACHED="${DETACHED:-1}"
+REMOTE_BUILD_LOG="${REMOTE_BUILD_LOG:-/tmp/altastata-s390x-jupyter-rag-build.log}"
 
 echo "Repo root: $REPO_ROOT"
 echo "SSH: $SSH_HOST (key: $SSH_KEY)"
-echo "REMOTE_DIR=$REMOTE_DIR  ENABLE_ZDNN=$ENABLE_ZDNN"
+echo "REMOTE_DIR=$REMOTE_DIR ENABLE_ZDNN=$ENABLE_ZDNN DETACHED=$DETACHED log=$REMOTE_BUILD_LOG"
 
-# --- Same account + repo prep as build-rag-s390x-on-server.sh (covers Jupyter needs too) ---
 if [ -n "$ALTASTATA_ACCOUNTS" ]; then
   echo "Syncing AltaStata accounts..."
   ssh $SSH_OPTS "$SSH_HOST" "mkdir -p $REMOTE_ALTASTATA_ACCOUNTS"
@@ -55,7 +55,7 @@ if [ -n "$ALTASTATA_ACCOUNTS" ]; then
   fi
 fi
 
-echo "Syncing repo to server (single rsync — safe for parallel docker builds afterward)..."
+echo "Syncing repo to LinuxONE ..."
 rsync -avz --delete \
   -e "ssh $SSH_OPTS" \
   --exclude '.git' \
@@ -82,7 +82,7 @@ if [ "$ENABLE_ZDNN" = "1" ]; then
       echo 'ERROR: /root/llama_models/$F16_FILE missing on server.'
       exit 2
     fi
-    ln -f /root/llama_models/$F16_FILE $REMOTE_DIR/containers/rag-example/$F16_FILE 2>/dev/null \
+    ln -f /root/llama_models/$F16_FILE $REMOTE_DIR/containers/rag-example/$F16_FILE 2>/dev/null \\
       || cp -f /root/llama_models/$F16_FILE $REMOTE_DIR/containers/rag-example/$F16_FILE
     ls -la $REMOTE_DIR/containers/rag-example/$F16_FILE
   "
@@ -94,47 +94,34 @@ else
   "
 fi
 
-echo "Building Jupyter + RAG on server concurrently (same host — heavy CPU/mem; consider larger VM)."
-# stdin script runs on LinuxONE — vars via env(1) passed by ssh.
-
-# shellcheck disable=SC2086
-ssh $SSH_OPTS "$SSH_HOST" env "REMOTE_DIR=$REMOTE_DIR" "ENABLE_ZDNN=$ENABLE_ZDNN" bash -s <<'REMOTE'
-set -eo pipefail
-cd "$REMOTE_DIR"
-# shellcheck source=/dev/null
-source version.sh
-echo "parallel: Jupyter jupyter-datascience-s390x ..."
-docker build --build-arg ALTASTATA_VERSION="${ALTASTATA_PYPI_VERSION}" \
-  -f containers/jupyter/Dockerfile.s390x \
-  -t altastata/jupyter-datascience-s390x:latest \
-  -t "altastata/jupyter-datascience-s390x:${JUPYTER_VERSION}" . &
-PID_J="$!"
-
-echo "parallel: RAG rag-open-llm-s390x ..."
-if [ "$ENABLE_ZDNN" = "1" ]; then
-  RAG_TAGS="-t altastata/rag-open-llm-s390x:${RAG_VERSION}_zdnn"
+if [ "$DETACHED" = "1" ]; then
+  echo "Starting builds on LinuxONE under nohup (this SSH exits now; Jupyter then RAG sequentially on the server)."
+  ssh $SSH_OPTS "$SSH_HOST" bash -s -- "$REMOTE_DIR" "$REMOTE_BUILD_LOG" "$ENABLE_ZDNN" <<'EOS'
+set -euo pipefail
+REMOTE_DIR="$1"
+BUILD_LOG="$2"
+ENABLE_ZDNN="$3"
+RUNNER="$REMOTE_DIR/containers/linuxone/build-jupyter-and-rag-on-linuxone.sh"
+chmod +x "$RUNNER" 2>/dev/null || true
+touch "$BUILD_LOG"
+nohup env ENABLE_ZDNN="$ENABLE_ZDNN" bash -eo pipefail "$RUNNER" >>"$BUILD_LOG" 2>&1 </dev/null &
+echo "Detached PID=$!  log=$BUILD_LOG"
+EOS
+  echo ""
+  echo "Tail on LinuxONE (from any machine): ssh $SSH_HOST tail -f $REMOTE_BUILD_LOG"
 else
-  RAG_TAGS="-t altastata/rag-open-llm-s390x:latest -t altastata/rag-open-llm-s390x:${RAG_VERSION}"
+  echo "Blocking mode: streaming build output from LinuxONE ..."
+  ssh $SSH_OPTS "$SSH_HOST" bash -s -- "$REMOTE_DIR" "$ENABLE_ZDNN" <<'EOS'
+set -euo pipefail
+REMOTE_DIR="$1"
+ENABLE_ZDNN="$2"
+RUNNER="$REMOTE_DIR/containers/linuxone/build-jupyter-and-rag-on-linuxone.sh"
+chmod +x "$RUNNER" 2>/dev/null || true
+exec env ENABLE_ZDNN="$ENABLE_ZDNN" bash -eo pipefail "$RUNNER"
+EOS
 fi
-# shellcheck disable=SC2086
-docker build --build-arg ENABLE_ZDNN="$ENABLE_ZDNN" \
-  -f containers/rag-example/Dockerfile.open_llm_s390x \
-  ${RAG_TAGS} . &
-PID_R="$!"
-
-ej=0
-er=0
-wait "$PID_J" || ej=$?
-wait "$PID_R" || er=$?
-if [ "$ej" -ne 0 ]; then echo "Jupyter docker build exited $ej"; fi
-if [ "$er" -ne 0 ]; then echo "RAG docker build exited $er"; fi
-exit $(( ej ? ej : er ? er : 0 ))
-REMOTE
 
 echo ""
-echo "Done. Tagged images on server:"
-echo "  altastata/jupyter-datascience-s390x:latest and :\$JUPYTER_VERSION"
-echo "  RAG default: altastata/rag-open-llm-s390x:latest and :\$RAG_VERSION ; zDNN: :\${RAG_VERSION}_zdnn"
-echo "(Use ../version.sh for exact strings.)"
+echo "When builds finish, images/tags follow version.sh (JUPYTER_VERSION, RAG_VERSION)."
 echo "Push Jupyter: ./containers/jupyter/push-jupyter-s390x-to-icr-from-server.sh"
 echo "Push RAG:     ICR_TOKEN=... ./containers/rag-example/push-rag-s390x-to-icr-from-server.sh"

--- a/containers/build-s390x-jupyter-and-rag-parallel-on-server.sh
+++ b/containers/build-s390x-jupyter-and-rag-parallel-on-server.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Optional: run from your Mac to rsync the repo to LinuxONE then start parallel
+# Docker builds *on the server* (still no Docker on Mac — only rsync + ssh).
+#
+# Prefer running everything on LinuxONE (no Mac workflows):
+#   ssh … "cd /path/to/altastata-python-package && git pull && ./containers/linuxone/build-jupyter-and-rag-in-parallel.sh"
+#
+# This script: one rsync prep, then Jupyter + RAG s390x builds IN PARALLEL on LinuxONE.
+# Avoids invoking build-jupyter + build-rag scripts together (their concurrent
+# rsync --delete races the same REMOTE_DIR and can corrupt context).
+#
+# Run from repo root:
+#   ./containers/build-s390x-jupyter-and-rag-parallel-on-server.sh
+# Optional same as rag script:
+#   ENABLE_ZDNN=1 SSH_HOST=...
+#
+# Prerequisites: SSH to server, Docker on server, same REMOTE_DIR default as sibling scripts.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SSH_KEY="${SSH_KEY:-/Users/sergevilvovsky/Downloads/torontolinuxonesshkey_rsa.prv}"
+SSH_HOST="${SSH_HOST:-root@163.66.89.80}"
+SSH_OPTS="-i $SSH_KEY -o StrictHostKeyChecking=accept-new -o GSSAPIAuthentication=no -o PreferredAuthentications=publickey"
+REMOTE_DIR="${REMOTE_DIR:-/tmp/altastata-python-package}"
+REMOTE_ALTASTATA_ACCOUNTS="${REMOTE_ALTASTATA_ACCOUNTS:-/root/.altastata/accounts}"
+REMOTE_HPCS_DIR="${REMOTE_HPCS_DIR:-/home/jovyan/hpcs}"
+ALTASTATA_ACCOUNTS="${ALTASTATA_ACCOUNTS:-$HOME/.altastata/accounts/amazon.rsa.bob123 $HOME/.altastata/accounts/amazon.rsa.hpcs.serge678}"
+ENABLE_ZDNN="${ENABLE_ZDNN:-0}"
+
+echo "Repo root: $REPO_ROOT"
+echo "SSH: $SSH_HOST (key: $SSH_KEY)"
+echo "REMOTE_DIR=$REMOTE_DIR  ENABLE_ZDNN=$ENABLE_ZDNN"
+
+# --- Same account + repo prep as build-rag-s390x-on-server.sh (covers Jupyter needs too) ---
+if [ -n "$ALTASTATA_ACCOUNTS" ]; then
+  echo "Syncing AltaStata accounts..."
+  ssh $SSH_OPTS "$SSH_HOST" "mkdir -p $REMOTE_ALTASTATA_ACCOUNTS"
+  for account in $ALTASTATA_ACCOUNTS; do
+    if [ -d "$account" ]; then
+      name="$(basename "$account")"
+      rsync -avz -e "ssh $SSH_OPTS" "$account/" "$SSH_HOST:$REMOTE_ALTASTATA_ACCOUNTS/$name/"
+      echo "  -> $name"
+    else
+      echo "  Skip (not found): $account"
+    fi
+  done
+  echo "Stripping HPCS path lines from account *.user.properties on server..."
+  ssh $SSH_OPTS "$SSH_HOST" "for f in $REMOTE_ALTASTATA_ACCOUNTS/*/*.user.properties; do [ -f \"\$f\" ] && sed -i '/^hpcs-yaml-path=/d' \"\$f\" && sed -i '/^hpcs-priv-key-blob-path=/d' \"\$f\" && echo \"  \$(basename \"\$f\")\"; done"
+  HPCS_BLOB_SRC="$HOME/.altastata/accounts/amazon.rsa.hpcs.serge678/hpcs-privkey.blob"
+  if [ -f "$HPCS_BLOB_SRC" ]; then
+    echo "Copying HPCS key blob to server..."
+    ssh $SSH_OPTS "$SSH_HOST" "mkdir -p $REMOTE_HPCS_DIR"
+    rsync -avz -e "ssh $SSH_OPTS" "$HPCS_BLOB_SRC" "$SSH_HOST:$REMOTE_HPCS_DIR/hpcs-privkey.blob"
+  fi
+fi
+
+echo "Syncing repo to server (single rsync — safe for parallel docker builds afterward)..."
+rsync -avz --delete \
+  -e "ssh $SSH_OPTS" \
+  --exclude '.git' \
+  --exclude '__pycache__' \
+  --exclude '*.pyc' \
+  --exclude '.env' \
+  --exclude 'local_index' \
+  "$REPO_ROOT/" "$SSH_HOST:$REMOTE_DIR/"
+
+HPCS_ACCOUNT="amazon.rsa.hpcs.serge678"
+HPCS_PROPERTIES_FILE="altastata-myorgrsa444-serge678.user.properties"
+HPCS_PROPERTIES_SRC="$REPO_ROOT/containers/rag-example/$HPCS_PROPERTIES_FILE"
+if [ -f "$HPCS_PROPERTIES_SRC" ]; then
+  echo "Copying $HPCS_PROPERTIES_FILE to server..."
+  ssh $SSH_OPTS "$SSH_HOST" "mkdir -p $REMOTE_ALTASTATA_ACCOUNTS/$HPCS_ACCOUNT && cp $REMOTE_DIR/containers/rag-example/$HPCS_PROPERTIES_FILE $REMOTE_ALTASTATA_ACCOUNTS/$HPCS_ACCOUNT/$HPCS_PROPERTIES_FILE && echo '  Done'"
+fi
+
+F16_FILE="llama-3.2-1b-instruct-be.f16.gguf"
+if [ "$ENABLE_ZDNN" = "1" ]; then
+  echo "ENABLE_ZDNN=1: staging real $F16_FILE into build context on server..."
+  ssh $SSH_OPTS "$SSH_HOST" "
+    set -e
+    if [ ! -f /root/llama_models/$F16_FILE ]; then
+      echo 'ERROR: /root/llama_models/$F16_FILE missing on server.'
+      exit 2
+    fi
+    ln -f /root/llama_models/$F16_FILE $REMOTE_DIR/containers/rag-example/$F16_FILE 2>/dev/null \
+      || cp -f /root/llama_models/$F16_FILE $REMOTE_DIR/containers/rag-example/$F16_FILE
+    ls -la $REMOTE_DIR/containers/rag-example/$F16_FILE
+  "
+else
+  ssh $SSH_OPTS "$SSH_HOST" "
+    set -e
+    : > $REMOTE_DIR/containers/rag-example/$F16_FILE
+    ls -la $REMOTE_DIR/containers/rag-example/$F16_FILE
+  "
+fi
+
+echo "Building Jupyter + RAG on server concurrently (same host — heavy CPU/mem; consider larger VM)."
+# stdin script runs on LinuxONE — vars via env(1) passed by ssh.
+
+# shellcheck disable=SC2086
+ssh $SSH_OPTS "$SSH_HOST" env "REMOTE_DIR=$REMOTE_DIR" "ENABLE_ZDNN=$ENABLE_ZDNN" bash -s <<'REMOTE'
+set -eo pipefail
+cd "$REMOTE_DIR"
+# shellcheck source=/dev/null
+source version.sh
+echo "parallel: Jupyter jupyter-datascience-s390x ..."
+docker build --build-arg ALTASTATA_VERSION="${ALTASTATA_PYPI_VERSION}" \
+  -f containers/jupyter/Dockerfile.s390x \
+  -t altastata/jupyter-datascience-s390x:latest \
+  -t "altastata/jupyter-datascience-s390x:${JUPYTER_VERSION}" . &
+PID_J="$!"
+
+echo "parallel: RAG rag-open-llm-s390x ..."
+if [ "$ENABLE_ZDNN" = "1" ]; then
+  RAG_TAGS="-t altastata/rag-open-llm-s390x:${RAG_VERSION}_zdnn"
+else
+  RAG_TAGS="-t altastata/rag-open-llm-s390x:latest -t altastata/rag-open-llm-s390x:${RAG_VERSION}"
+fi
+# shellcheck disable=SC2086
+docker build --build-arg ENABLE_ZDNN="$ENABLE_ZDNN" \
+  -f containers/rag-example/Dockerfile.open_llm_s390x \
+  ${RAG_TAGS} . &
+PID_R="$!"
+
+ej=0
+er=0
+wait "$PID_J" || ej=$?
+wait "$PID_R" || er=$?
+if [ "$ej" -ne 0 ]; then echo "Jupyter docker build exited $ej"; fi
+if [ "$er" -ne 0 ]; then echo "RAG docker build exited $er"; fi
+exit $(( ej ? ej : er ? er : 0 ))
+REMOTE
+
+echo ""
+echo "Done. Tagged images on server:"
+echo "  altastata/jupyter-datascience-s390x:latest and :\$JUPYTER_VERSION"
+echo "  RAG default: altastata/rag-open-llm-s390x:latest and :\$RAG_VERSION ; zDNN: :\${RAG_VERSION}_zdnn"
+echo "(Use ../version.sh for exact strings.)"
+echo "Push Jupyter: ./containers/jupyter/push-jupyter-s390x-to-icr-from-server.sh"
+echo "Push RAG:     ICR_TOKEN=... ./containers/rag-example/push-rag-s390x-to-icr-from-server.sh"

--- a/containers/jupyter/Dockerfile.amd64
+++ b/containers/jupyter/Dockerfile.amd64
@@ -37,6 +37,22 @@ RUN echo "Installing regular packages" && \
 RUN echo "Installing PyTorch CPU packages" && \
     pip install --no-cache-dir --upgrade-strategy only-if-needed -r pytorch-cpu.txt --index-url https://download.pytorch.org/whl/cpu
 
+# Install AltaStata in its own layer — pinned via build ARG so bumping the version
+# invalidates only this small layer (PyTorch / requirements layers above stay cached).
+# Single source of truth lives in setup.py: the build scripts
+# (containers/jupyter/build-all-images.sh, push-to-ghcr.sh) source version.sh
+# which auto-extracts ALTASTATA_PYPI_VERSION from setup.py and forwards it as
+# --build-arg ALTASTATA_VERSION. ARG default is intentionally empty: ad-hoc
+# `docker build .` then installs the latest from PyPI; the build script always
+# pins to setup.py's version, which is the canonical path.
+ARG ALTASTATA_VERSION=
+RUN if [ -n "${ALTASTATA_VERSION}" ]; then \
+        pip install --no-cache-dir "altastata==${ALTASTATA_VERSION}" ; \
+    else \
+        echo "WARN: ALTASTATA_VERSION not set (build script overrides this). Installing latest from PyPI." && \
+        pip install --no-cache-dir altastata ; \
+    fi
+
 # Copy pytorch-example for reference
 COPY --chown=1001:0 examples/pytorch-example /opt/app-root/src/pytorch-example/
 

--- a/containers/jupyter/Dockerfile.arm64
+++ b/containers/jupyter/Dockerfile.arm64
@@ -18,9 +18,28 @@ RUN mkdir -p /opt/app-root/src && \
 # Install only altastata and PyTorch
 # Use setuptools<75 for pkg_resources (conda setuptools 82 lacks it for Python 3.13)
 # Note: torchaudio 2.5.1 not available for Python 3.13/ARM64; using latest compatible versions
-RUN pip install --no-cache-dir "setuptools<75" && \
-    pip install --no-cache-dir altastata && \
-    pip install --no-cache-dir torch torchvision torchaudio
+#
+# Split into three RUN steps so a Docker layer-cache only invalidates from the
+# changed step downward. PyTorch is ~2 GB to download — keep it in its own
+# layer so an altastata version bump doesn't force a re-pull.
+#
+# altastata is pinned via a build ARG so the layer's pip command text changes
+# whenever the version is bumped — this invalidates the cache for that one layer
+# without --no-cache. Single source of truth lives in setup.py: the build scripts
+# (containers/jupyter/build-all-images.sh, push-to-ghcr.sh) source version.sh
+# which auto-extracts ALTASTATA_PYPI_VERSION from setup.py and forwards it as
+# --build-arg ALTASTATA_VERSION. ARG default is intentionally empty: ad-hoc
+# `docker build .` then installs the latest from PyPI; the build script always
+# pins to setup.py's version, which is the canonical path.
+RUN pip install --no-cache-dir "setuptools<75"
+RUN pip install --no-cache-dir torch torchvision torchaudio
+ARG ALTASTATA_VERSION=
+RUN if [ -n "${ALTASTATA_VERSION}" ]; then \
+        pip install --no-cache-dir "altastata==${ALTASTATA_VERSION}" ; \
+    else \
+        echo "WARN: ALTASTATA_VERSION not set (build script overrides this). Installing latest from PyPI." && \
+        pip install --no-cache-dir altastata ; \
+    fi
 
 # Copy pytorch-example for reference
 COPY --chown=${NB_UID}:${NB_GID} examples/pytorch-example /opt/app-root/src/pytorch-example/

--- a/containers/jupyter/Dockerfile.s390x
+++ b/containers/jupyter/Dockerfile.s390x
@@ -41,6 +41,22 @@ ENV ZMQ_BUILD_BUNDLED=0
 RUN echo "Installing regular packages" && \
     pip install --no-cache-dir --upgrade-strategy only-if-needed -r /tmp/requirements.txt
 
+# Install AltaStata in its own layer — pinned via build ARG so bumping the version
+# invalidates only this small layer (the much larger requirements layer above stays
+# cached). Single source of truth lives in setup.py: the build scripts
+# (containers/jupyter/build-all-images.sh, push-to-ghcr.sh) source version.sh
+# which auto-extracts ALTASTATA_PYPI_VERSION from setup.py and forwards it as
+# --build-arg ALTASTATA_VERSION. ARG default is intentionally empty: ad-hoc
+# `docker build .` then installs the latest from PyPI; the build script always
+# pins to setup.py's version, which is the canonical path.
+ARG ALTASTATA_VERSION=
+RUN if [ -n "${ALTASTATA_VERSION}" ]; then \
+        pip install --no-cache-dir "altastata==${ALTASTATA_VERSION}" ; \
+    else \
+        echo "WARN: ALTASTATA_VERSION not set (build script overrides this). Installing latest from PyPI." && \
+        pip install --no-cache-dir altastata ; \
+    fi
+
 # Copy pytorch-example for reference
 COPY --chown=1001:0 examples/pytorch-example /opt/app-root/src/pytorch-example/
 

--- a/containers/jupyter/IBM-LINUXONE-S390X-SETUP.md
+++ b/containers/jupyter/IBM-LINUXONE-S390X-SETUP.md
@@ -349,7 +349,7 @@ Set `SSH_HOST` and `SSH_KEY` if needed (see script defaults). The script uses `G
 
 **Run the container** (after build or pull):
 - After pushing to ICR, from your Mac run `./containers/rag-example/pull-and-run-rag-s390x-from-icr.sh` to pull and run on the server (or run `docker run` manually on the server).
-- Manually on the server: use the same `docker run` as in [examples/rag-example/open_llm/README.md](../../examples/rag-example/open_llm/README.md) (env `ALTASTATA_ACCOUNT_DIR`, `HF_LLM_MODEL`, volume mount for `$HOME/.altastata/accounts`). For HPCS accounts add `-e ALTASTATA_USE_HPCS=1`. Open `http://<host>:8000/`.
+- Manually on the server: use the same `docker run` as in [examples/rag-example/open_llm/README.md](../../examples/rag-example/open_llm/README.md) (env `ALTASTATA_ACCOUNT_DIR`, `HF_LLM_MODEL`, volume mount for `$HOME/.altastata/accounts`). For HPCS accounts add `-e ALTASTATA_USE_HPCS=1`, mount `/home/jovyan/hpcs:/home/jovyan/hpcs:ro`, and set `HPCS_PRIV_KEY_BLOB_PATH=/home/jovyan/hpcs/hpcs-privkey.blob`. Open `http://<host>:8000/`.
 
 On **8 GB VMs** use **gpt2** (`HF_LLM_MODEL=gpt2`); on 16+ GB use `HF_LLM_MODEL=TinyLlama/TinyLlama-1.1B-Chat-v1.0`. See [examples/rag-example/open_llm/README.md](../../examples/rag-example/open_llm/README.md) for full s390x options (watsonx, llama.cpp, etc.).
 

--- a/containers/jupyter/README-ICR-BUILD-AND-PUSH.md
+++ b/containers/jupyter/README-ICR-BUILD-AND-PUSH.md
@@ -52,7 +52,7 @@ docker tag altastata/jupyter-datascience-s390x:${VERSION} icr.io/altastata/jupyt
 We use IBM Container Registry (icr.io) only—no Docker Hub. Log in with your ICR API key (iamapikey), not a Docker ID:
 
 ```bash
-export ICR_TOKEN="PASTE_NICOLAS_TOKEN_HERE"
+export ICR_TOKEN="PASTE_YOUR_ICR_API_KEY_HERE"
 echo "$ICR_TOKEN" | docker login -u iamapikey --password-stdin icr.io
 ```
 
@@ -98,7 +98,7 @@ Uses the same **VERSION** as the Jupyter notebook image (from `version.sh`, curr
 
 **Push from server** (image was built with `build-rag-s390x-on-server.sh`):
 ```bash
-export ICR_TOKEN="PASTE_NICOLAS_TOKEN_HERE"
+export ICR_TOKEN="PASTE_YOUR_ICR_API_KEY_HERE"
 ./containers/rag-example/push-rag-s390x-to-icr-from-server.sh
 ```
 

--- a/containers/jupyter/README-ICR-BUILD-AND-PUSH.md
+++ b/containers/jupyter/README-ICR-BUILD-AND-PUSH.md
@@ -9,19 +9,30 @@ then tagging and pushing the s390x image to IBM Container Registry (ICR).
 - Access token for ICR (provided by IBM/ICR admin)
 - Access to the `altastata` ICR namespace
 
+## Versioning at a glance
+
+`version.sh` exposes two image tags (different release cadences):
+
+- `JUPYTER_VERSION` (currently `2026c_latest`) — used for `jupyter-datascience-{arm64,amd64,s390x}`.
+- `RAG_VERSION` (currently `2026g_latest`) — used for `rag-open-llm-s390x`. The `:${RAG_VERSION}_zdnn` variant is the research/zDNN-on build; the plain tag is the default CPU build.
+
+Source `version.sh` once and the rest of these examples just use `${JUPYTER_VERSION}` / `${RAG_VERSION}`.
+
 ## Build s390x (IBM base)
 
 On macOS, use buildx to produce a real s390x image:
 
 ```bash
+source version.sh
 docker buildx build --platform linux/s390x -f containers/jupyter/Dockerfile.s390x \
-  -t altastata/jupyter-datascience-s390x:2026c_latest --load .
+  -t altastata/jupyter-datascience-s390x:${JUPYTER_VERSION} --load .
 ```
 
 If you are already on an s390x host, a normal build is fine:
 
 ```bash
-docker build -f containers/jupyter/Dockerfile.s390x -t altastata/jupyter-datascience-s390x:2026c_latest .
+source version.sh
+docker build -f containers/jupyter/Dockerfile.s390x -t altastata/jupyter-datascience-s390x:${JUPYTER_VERSION} .
 ```
 
 ## Build arm64 (local testing on macOS)
@@ -42,9 +53,8 @@ Then open http://localhost:8889/lab and use the token from logs: `docker logs <c
 ## Tag s390x image for ICR
 
 ```bash
-# Version from version.sh (e.g. 2026c_latest)
-source version.sh 2>/dev/null || VERSION="2026c_latest"
-docker tag altastata/jupyter-datascience-s390x:${VERSION} icr.io/altastata/jupyter-datascience-s390x:${VERSION}
+source version.sh
+docker tag altastata/jupyter-datascience-s390x:${JUPYTER_VERSION} icr.io/altastata/jupyter-datascience-s390x:${JUPYTER_VERSION}
 ```
 
 ## Login to ICR
@@ -59,7 +69,7 @@ echo "$ICR_TOKEN" | docker login -u iamapikey --password-stdin icr.io
 ## Push to ICR
 
 ```bash
-docker push icr.io/altastata/jupyter-datascience-s390x:${VERSION}
+docker push icr.io/altastata/jupyter-datascience-s390x:${JUPYTER_VERSION}
 ```
 
 Optional logout:
@@ -80,21 +90,23 @@ Same pattern for the RAG s390x image: build (on s390x host or with buildx), tag 
 
 ```bash
 # On the s390x server (or from Mac via build-rag-s390x-on-server.sh)
-source version.sh 2>/dev/null || true
-docker build -f containers/rag-example/Dockerfile.open_llm_s390x -t altastata/rag-open-llm-s390x:latest -t altastata/rag-open-llm-s390x:${VERSION:-2026c_latest} .
+source version.sh
+docker build -f containers/rag-example/Dockerfile.open_llm_s390x -t altastata/rag-open-llm-s390x:latest -t altastata/rag-open-llm-s390x:${RAG_VERSION} .
 ```
 
 **On macOS with buildx** (cross-build; no cache from previous s390x builds):
 
 ```bash
-source version.sh 2>/dev/null || true
+source version.sh
 docker buildx build --platform linux/s390x -f containers/rag-example/Dockerfile.open_llm_s390x \
-  -t altastata/rag-open-llm-s390x:latest -t altastata/rag-open-llm-s390x:${VERSION:-2026c_latest} --load .
+  -t altastata/rag-open-llm-s390x:latest -t altastata/rag-open-llm-s390x:${RAG_VERSION} --load .
 ```
+
+(`ENABLE_ZDNN=1 ./containers/rag-example/build-rag-s390x-on-server.sh` tags only `:${RAG_VERSION}_zdnn`, not `:latest`; use the scripts for that.)
 
 ### Tag and push RAG s390x to ICR
 
-Uses the same **VERSION** as the Jupyter notebook image (from `version.sh`, currently **2026c_latest**).
+Uses **`RAG_VERSION`** from `version.sh` (currently **`2026g_latest`** — different from Jupyter’s **`JUPYTER_VERSION`** / `2026c_latest`).
 
 **Push from server** (image was built with `build-rag-s390x-on-server.sh`):
 ```bash
@@ -104,11 +116,13 @@ export ICR_TOKEN="PASTE_YOUR_ICR_API_KEY_HERE"
 
 **Or manual (on the server):**
 ```bash
-source version.sh 2>/dev/null || VERSION="2026c_latest"
-docker tag altastata/rag-open-llm-s390x:latest icr.io/altastata/rag-open-llm-s390x:${VERSION}
+source version.sh
+docker tag altastata/rag-open-llm-s390x:latest icr.io/altastata/rag-open-llm-s390x:${RAG_VERSION}
 echo "$ICR_TOKEN" | docker login -u iamapikey --password-stdin icr.io
-docker push icr.io/altastata/rag-open-llm-s390x:${VERSION}
+docker push icr.io/altastata/rag-open-llm-s390x:${RAG_VERSION}
 ```
+
+For the **`${RAG_VERSION}_zdnn`** research image, set **`ENABLE_ZDNN=1`** when running **`push-rag-s390x-to-icr-from-server.sh`** (see script header).
 
 ### Pull and run (for users who pull from ICR)
 
@@ -132,14 +146,14 @@ If you see **"manifest not found"**, the image is not in ICR yet—build on the 
 
 **Or manually on the s390x server:**
 ```bash
-source version.sh 2>/dev/null || VERSION="2026c_latest"
-docker pull icr.io/altastata/rag-open-llm-s390x:${VERSION}
+source version.sh
+docker pull icr.io/altastata/rag-open-llm-s390x:${RAG_VERSION}
 # Password-based account (e.g. bob123):
 docker run -d -p 8000:8000 --name rag \
   -e ALTASTATA_ACCOUNT_DIR=/root/.altastata/accounts/amazon.rsa.bob123 \
   -e HF_LLM_MODEL=TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
   -v $HOME/.altastata/accounts:/root/.altastata/accounts:ro \
-  icr.io/altastata/rag-open-llm-s390x:${VERSION}
+  icr.io/altastata/rag-open-llm-s390x:${RAG_VERSION}
 # HPCS account (no password): add -e ALTASTATA_USE_HPCS=1
 # Open http://<host>:8000/
 ```

--- a/containers/jupyter/build-all-images.sh
+++ b/containers/jupyter/build-all-images.sh
@@ -15,8 +15,14 @@ if [ -z "$VERSION" ]; then
     echo "Please ensure version.sh contains: VERSION=\"your_version\""
     exit 1
 fi
+if [ -z "$ALTASTATA_PYPI_VERSION" ]; then
+    echo "Error: ALTASTATA_PYPI_VERSION not extracted from setup.py (see version.sh)"
+    exit 1
+fi
 
 echo "🚀 Building Altastata Python Package Docker Images (ARM64 + AMD64)..."
+echo "   image tag:        ${VERSION}"
+echo "   altastata (PyPI): ${ALTASTATA_PYPI_VERSION}"
 
 # Create Docker network if it doesn't exist (shared with main altastata project)
 echo "Creating shared Docker network..."
@@ -31,6 +37,7 @@ echo ""
 echo "🏗️  Building jupyter-datascience-arm64..."
 cd "$REPO_ROOT"
 docker build -f containers/jupyter/Dockerfile.arm64 \
+    --build-arg ALTASTATA_VERSION=${ALTASTATA_PYPI_VERSION} \
     -t altastata/jupyter-datascience-arm64:latest \
     -t altastata/jupyter-datascience-arm64:${VERSION} \
     .
@@ -39,6 +46,7 @@ docker build -f containers/jupyter/Dockerfile.arm64 \
 echo ""
 echo "🏗️  Building jupyter-datascience-amd64..."
 docker buildx build --platform linux/amd64 -f containers/jupyter/Dockerfile.amd64 \
+    --build-arg ALTASTATA_VERSION=${ALTASTATA_PYPI_VERSION} \
     -t altastata/jupyter-datascience-amd64:latest \
     -t altastata/jupyter-datascience-amd64:${VERSION} \
     --load \

--- a/containers/jupyter/build-all-images.sh
+++ b/containers/jupyter/build-all-images.sh
@@ -9,16 +9,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 source "${REPO_ROOT}/version.sh"
 
-# Validate version is set
-if [ -z "$VERSION" ]; then
-    echo "Error: VERSION is not set in version.sh"
-    echo "Please ensure version.sh contains: VERSION=\"your_version\""
+if [ -z "$JUPYTER_VERSION" ]; then
+    echo "Error: JUPYTER_VERSION not set in version.sh"
     exit 1
 fi
 if [ -z "$ALTASTATA_PYPI_VERSION" ]; then
     echo "Error: ALTASTATA_PYPI_VERSION not extracted from setup.py (see version.sh)"
     exit 1
 fi
+VERSION="$JUPYTER_VERSION"
 
 echo "🚀 Building Altastata Python Package Docker Images (ARM64 + AMD64)..."
 echo "   image tag:        ${VERSION}"

--- a/containers/jupyter/build-jupyter-s390x-on-server.sh
+++ b/containers/jupyter/build-jupyter-s390x-on-server.sh
@@ -61,7 +61,7 @@ rsync -avz --delete \
 # Single source of truth: version.sh extracts ALTASTATA_PYPI_VERSION from setup.py
 # and forwards it to the s390x Dockerfile via --build-arg, so the s390x image
 # always pins the same altastata version as the Mac/AMD64 ones (no silent drift
-# to "latest from PyPI" if we publish 0.1.28 next week).
+# to "latest from PyPI" when we bump setup.py).
 source "$REPO_ROOT/version.sh"
 echo "Building image on server (tag: $VERSION, altastata==$ALTASTATA_PYPI_VERSION)..."
 ssh $SSH_OPTS "$SSH_HOST" "cd $REMOTE_DIR && source version.sh && docker build --build-arg ALTASTATA_VERSION=\$ALTASTATA_PYPI_VERSION -f containers/jupyter/Dockerfile.s390x -t altastata/jupyter-datascience-s390x:latest -t altastata/jupyter-datascience-s390x:\$VERSION ."

--- a/containers/jupyter/build-jupyter-s390x-on-server.sh
+++ b/containers/jupyter/build-jupyter-s390x-on-server.sh
@@ -63,16 +63,16 @@ rsync -avz --delete \
 # always pins the same altastata version as the Mac/AMD64 ones (no silent drift
 # to "latest from PyPI" when we bump setup.py).
 source "$REPO_ROOT/version.sh"
-echo "Building image on server (tag: $VERSION, altastata==$ALTASTATA_PYPI_VERSION)..."
-ssh $SSH_OPTS "$SSH_HOST" "cd $REMOTE_DIR && source version.sh && docker build --build-arg ALTASTATA_VERSION=\$ALTASTATA_PYPI_VERSION -f containers/jupyter/Dockerfile.s390x -t altastata/jupyter-datascience-s390x:latest -t altastata/jupyter-datascience-s390x:\$VERSION ."
+echo "Building image on server (tag: $JUPYTER_VERSION, altastata==$ALTASTATA_PYPI_VERSION)..."
+ssh $SSH_OPTS "$SSH_HOST" "cd $REMOTE_DIR && source version.sh && docker build --build-arg ALTASTATA_VERSION=\$ALTASTATA_PYPI_VERSION -f containers/jupyter/Dockerfile.s390x -t altastata/jupyter-datascience-s390x:latest -t altastata/jupyter-datascience-s390x:\$JUPYTER_VERSION ."
 
 echo ""
-echo "Done. Image altastata/jupyter-datascience-s390x:$VERSION (and :latest) is on the server."
+echo "Done. Image altastata/jupyter-datascience-s390x:$JUPYTER_VERSION (and :latest) is on the server."
 echo "Accounts (if synced) are under $REMOTE_ALTASTATA_ACCOUNTS. Run with:"
 echo "  ssh -i $SSH_KEY $SSH_HOST 'docker run -d --name altastata-jupyter-s390x \\"
 echo "    -p 8888:8888 \\"
 echo "    -v $REMOTE_ALTASTATA_ACCOUNTS:/home/jovyan/.altastata/accounts:ro \\"
-echo "    altastata/jupyter-datascience-s390x:$VERSION'"
+echo "    altastata/jupyter-datascience-s390x:$JUPYTER_VERSION'"
 echo ""
 echo "Then get the token:"
 echo "  ssh -i $SSH_KEY $SSH_HOST 'docker exec altastata-jupyter-s390x jupyter server list'"

--- a/containers/jupyter/build-jupyter-s390x-on-server.sh
+++ b/containers/jupyter/build-jupyter-s390x-on-server.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Build the Jupyter DataScience s390x image ON the LinuxONE server.
+# Mirror of containers/rag-example/build-rag-s390x-on-server.sh — keeps the
+# Jupyter and RAG s390x build flows symmetric (same SSH plumbing, same
+# version.sh single-source-of-truth, same tag scheme).
+#
+# Run from repo root on your Mac (with the SSH key and server reachable).
+#
+# Usage:
+#   ./containers/jupyter/build-jupyter-s390x-on-server.sh
+# Or with custom host/key:
+#   SSH_KEY=~/.ssh/my.key SSH_HOST=user@10.0.0.1 ./containers/jupyter/build-jupyter-s390x-on-server.sh
+#
+# Set ALTASTATA_ACCOUNTS="" to skip syncing accounts (build-only, no test data).
+#
+# If SSH does not connect: check (1) you're on a network that can reach the server (VPN, firewall),
+# (2) SSH_HOST and SSH_KEY are correct, (3) server is up and sshd is running. Test with:
+#   ssh -i "$SSH_KEY" $SSH_HOST "echo ok"
+
+set -e
+# Repo root = directory that contains containers/ and examples/ (altastata-python-package)
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SSH_KEY="${SSH_KEY:-/Users/sergevilvovsky/Downloads/torontolinuxonesshkey_rsa.prv}"
+SSH_HOST="${SSH_HOST:-root@163.66.89.80}"
+# Speed up SSH (avoid GSSAPI/reverse-DNS delays)
+SSH_OPTS="-i $SSH_KEY -o StrictHostKeyChecking=accept-new -o GSSAPIAuthentication=no -o PreferredAuthentications=publickey"
+REMOTE_DIR="${REMOTE_DIR:-/tmp/altastata-python-package}"
+REMOTE_ALTASTATA_ACCOUNTS="${REMOTE_ALTASTATA_ACCOUNTS:-/root/.altastata/accounts}"
+# Local AltaStata accounts to copy for testing (set ALTASTATA_ACCOUNTS="" to skip).
+# Same default as the RAG build script so both share /root/.altastata/accounts on the server.
+ALTASTATA_ACCOUNTS="${ALTASTATA_ACCOUNTS:-$HOME/.altastata/accounts/amazon.rsa.bob123 $HOME/.altastata/accounts/amazon.rsa.hpcs.serge678}"
+
+echo "Repo root: $REPO_ROOT"
+echo "SSH: $SSH_HOST (key: $SSH_KEY)"
+echo "Remote dir: $REMOTE_DIR"
+
+if [ -n "$ALTASTATA_ACCOUNTS" ]; then
+  echo "Syncing AltaStata accounts to server ($REMOTE_ALTASTATA_ACCOUNTS)..."
+  ssh $SSH_OPTS "$SSH_HOST" "mkdir -p $REMOTE_ALTASTATA_ACCOUNTS"
+  for account in $ALTASTATA_ACCOUNTS; do
+    if [ -d "$account" ]; then
+      name="$(basename "$account")"
+      rsync -avz -e "ssh $SSH_OPTS" "$account/" "$SSH_HOST:$REMOTE_ALTASTATA_ACCOUNTS/$name/"
+      echo "  -> $name"
+    else
+      echo "  Skip (not found): $account"
+    fi
+  done
+fi
+
+echo "Syncing repo to server..."
+rsync -avz --delete \
+  -e "ssh $SSH_OPTS" \
+  --exclude '.git' \
+  --exclude '__pycache__' \
+  --exclude '*.pyc' \
+  --exclude '.env' \
+  --exclude 'local_index' \
+  "$REPO_ROOT/" "$SSH_HOST:$REMOTE_DIR/"
+
+# Single source of truth: version.sh extracts ALTASTATA_PYPI_VERSION from setup.py
+# and forwards it to the s390x Dockerfile via --build-arg, so the s390x image
+# always pins the same altastata version as the Mac/AMD64 ones (no silent drift
+# to "latest from PyPI" if we publish 0.1.28 next week).
+source "$REPO_ROOT/version.sh"
+echo "Building image on server (tag: $VERSION, altastata==$ALTASTATA_PYPI_VERSION)..."
+ssh $SSH_OPTS "$SSH_HOST" "cd $REMOTE_DIR && source version.sh && docker build --build-arg ALTASTATA_VERSION=\$ALTASTATA_PYPI_VERSION -f containers/jupyter/Dockerfile.s390x -t altastata/jupyter-datascience-s390x:latest -t altastata/jupyter-datascience-s390x:\$VERSION ."
+
+echo ""
+echo "Done. Image altastata/jupyter-datascience-s390x:$VERSION (and :latest) is on the server."
+echo "Accounts (if synced) are under $REMOTE_ALTASTATA_ACCOUNTS. Run with:"
+echo "  ssh -i $SSH_KEY $SSH_HOST 'docker run -d --name altastata-jupyter-s390x \\"
+echo "    -p 8888:8888 \\"
+echo "    -v $REMOTE_ALTASTATA_ACCOUNTS:/home/jovyan/.altastata/accounts:ro \\"
+echo "    altastata/jupyter-datascience-s390x:$VERSION'"
+echo ""
+echo "Then get the token:"
+echo "  ssh -i $SSH_KEY $SSH_HOST 'docker exec altastata-jupyter-s390x jupyter server list'"
+echo ""
+echo "Push to ICR for end users: ICR_TOKEN=... ./containers/jupyter/push-jupyter-s390x-to-icr-from-server.sh"

--- a/containers/jupyter/push-jupyter-s390x-to-icr-from-server.sh
+++ b/containers/jupyter/push-jupyter-s390x-to-icr-from-server.sh
@@ -19,9 +19,9 @@ if [ -z "$ICR_TOKEN" ]; then
   exit 1
 fi
 
-echo "Pushing from server $SSH_HOST to icr.io/altastata/jupyter-datascience-s390x:$VERSION"
+echo "Pushing from server $SSH_HOST to icr.io/altastata/jupyter-datascience-s390x:$JUPYTER_VERSION"
 echo "Logging in to icr.io on server..."
 echo "$ICR_TOKEN" | ssh $SSH_OPTS "$SSH_HOST" "docker login -u iamapikey --password-stdin icr.io"
 echo "Tag and push..."
-ssh $SSH_OPTS "$SSH_HOST" "docker tag altastata/jupyter-datascience-s390x:latest icr.io/altastata/jupyter-datascience-s390x:$VERSION && docker push icr.io/altastata/jupyter-datascience-s390x:$VERSION"
-echo "Done. Pull with: docker pull icr.io/altastata/jupyter-datascience-s390x:$VERSION"
+ssh $SSH_OPTS "$SSH_HOST" "docker tag altastata/jupyter-datascience-s390x:latest icr.io/altastata/jupyter-datascience-s390x:$JUPYTER_VERSION && docker push icr.io/altastata/jupyter-datascience-s390x:$JUPYTER_VERSION"
+echo "Done. Pull with: docker pull icr.io/altastata/jupyter-datascience-s390x:$JUPYTER_VERSION"

--- a/containers/jupyter/push-jupyter-s390x-to-icr-from-server.sh
+++ b/containers/jupyter/push-jupyter-s390x-to-icr-from-server.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Push the Jupyter DataScience s390x image from the LinuxONE server to ICR.
+# Mirror of containers/rag-example/push-rag-s390x-to-icr-from-server.sh.
+# Prereq: image built on server (./containers/jupyter/build-jupyter-s390x-on-server.sh). ICR_TOKEN on your Mac.
+# Run from repo root: ICR_TOKEN=... ./containers/jupyter/push-jupyter-s390x-to-icr-from-server.sh
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$REPO_ROOT/version.sh"
+SSH_KEY="${SSH_KEY:-/Users/sergevilvovsky/Downloads/torontolinuxonesshkey_rsa.prv}"
+SSH_HOST="${SSH_HOST:-root@163.66.89.80}"
+SSH_OPTS="-i $SSH_KEY -o StrictHostKeyChecking=accept-new -o GSSAPIAuthentication=no -o PreferredAuthentications=publickey"
+
+if [ -z "$ICR_TOKEN" ]; then
+  echo "Set ICR_TOKEN (your ICR API key) and run again, e.g.:"
+  echo "  export ICR_TOKEN=\"your_icr_api_key\""
+  echo "  $0"
+  exit 1
+fi
+
+echo "Pushing from server $SSH_HOST to icr.io/altastata/jupyter-datascience-s390x:$VERSION"
+echo "Logging in to icr.io on server..."
+echo "$ICR_TOKEN" | ssh $SSH_OPTS "$SSH_HOST" "docker login -u iamapikey --password-stdin icr.io"
+echo "Tag and push..."
+ssh $SSH_OPTS "$SSH_HOST" "docker tag altastata/jupyter-datascience-s390x:latest icr.io/altastata/jupyter-datascience-s390x:$VERSION && docker push icr.io/altastata/jupyter-datascience-s390x:$VERSION"
+echo "Done. Pull with: docker pull icr.io/altastata/jupyter-datascience-s390x:$VERSION"

--- a/containers/jupyter/push-to-ghcr.sh
+++ b/containers/jupyter/push-to-ghcr.sh
@@ -9,16 +9,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 source "${REPO_ROOT}/version.sh"
 
-# Validate version is set
-if [ -z "$VERSION" ]; then
-    echo "Error: VERSION is not set in version.sh"
-    echo "Please ensure version.sh contains: VERSION=\"your_version\""
+if [ -z "$JUPYTER_VERSION" ]; then
+    echo "Error: JUPYTER_VERSION not set in version.sh"
     exit 1
 fi
 if [ -z "$ALTASTATA_PYPI_VERSION" ]; then
     echo "Error: ALTASTATA_PYPI_VERSION not extracted from setup.py (see version.sh)"
     exit 1
 fi
+# Local alias so the rest of the script (and echo lines) can keep using $VERSION.
+VERSION="$JUPYTER_VERSION"
 
 # Check if GitHub token is set
 if [ -z "$GITHUB_TOKEN" ]; then

--- a/containers/jupyter/push-to-ghcr.sh
+++ b/containers/jupyter/push-to-ghcr.sh
@@ -3,7 +3,9 @@
 # Altastata Python Package GHCR Push Script
 # This script builds and pushes Docker images to GitHub Container Registry
 # Run from repo root: ./containers/jupyter/push-to-ghcr.sh
-# Separate packages: jupyter-datascience-arm64, jupyter-datascience-amd64
+# Default: arm64 (Apple Silicon) only — native build + push.
+# SKIP_JUPYTER_ARM64_BUILD=1 skips `docker build` and only runs `docker push` (tag must exist locally).
+# PUSH_JUPYTER_AMD64_TO_GHCR=1 also builds linux/amd64 via buildx (slow on Mac).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -33,39 +35,64 @@ fi
 echo "Logging in to GitHub Container Registry..."
 echo $GITHUB_TOKEN | docker login ghcr.io -u sergevil --password-stdin
 
-# Create and use buildx builder instance if it doesn't exist
-echo "🔧 Setting up Docker buildx..."
-docker buildx create --name altastata-builder --use 2>/dev/null || docker buildx use altastata-builder
+if [[ "${PUSH_JUPYTER_AMD64_TO_GHCR:-}" == "1" ]]; then
+    echo "🔧 Setting up Docker buildx (needed for amd64 cross-build)..."
+    docker buildx create --name altastata-builder --use 2>/dev/null || docker buildx use altastata-builder
+fi
 
-echo "Building and pushing jupyter-datascience images to GHCR..."
-echo "Packages: jupyter-datascience-arm64, jupyter-datascience-amd64"
+echo "Building and pushing jupyter-datascience image(s) to GHCR..."
+if [[ "${PUSH_JUPYTER_AMD64_TO_GHCR:-}" == "1" ]]; then
+    echo "Packages: jupyter-datascience-arm64, jupyter-datascience-amd64"
+else
+    echo "Packages: jupyter-datascience-arm64 only (set PUSH_JUPYTER_AMD64_TO_GHCR=1 to include amd64)"
+fi
+if [[ "${SKIP_JUPYTER_ARM64_BUILD:-}" == "1" ]]; then
+    echo "SKIP_JUPYTER_ARM64_BUILD=1: will not rebuild arm64; push only if tag exists locally."
+fi
 echo ""
 
 cd "$REPO_ROOT"
 
-# Build and push jupyter-datascience-arm64
-echo "Building and pushing jupyter-datascience-arm64 (altastata ${ALTASTATA_PYPI_VERSION})..."
-docker build -f containers/jupyter/Dockerfile.arm64 \
-    --build-arg ALTASTATA_VERSION=${ALTASTATA_PYPI_VERSION} \
-    -t ghcr.io/sergevil/altastata/jupyter-datascience-arm64:${VERSION} . && \
-    docker push ghcr.io/sergevil/altastata/jupyter-datascience-arm64:${VERSION}
+ARM64_IMG="ghcr.io/sergevil/altastata/jupyter-datascience-arm64:${VERSION}"
 
-# Build and push jupyter-datascience-amd64
-echo ""
-echo "Building and pushing jupyter-datascience-amd64 (altastata ${ALTASTATA_PYPI_VERSION})..."
-docker buildx build --platform linux/amd64 --file containers/jupyter/Dockerfile.amd64 \
-    --build-arg ALTASTATA_VERSION=${ALTASTATA_PYPI_VERSION} \
-    --tag ghcr.io/sergevil/altastata/jupyter-datascience-amd64:${VERSION} \
-    --push .
+if [[ "${SKIP_JUPYTER_ARM64_BUILD:-}" == "1" ]]; then
+    echo "Pushing existing jupyter-datascience-arm64 (altastata ${ALTASTATA_PYPI_VERSION}), tag ${VERSION}..."
+    if ! docker image inspect "${ARM64_IMG}" >/dev/null 2>&1; then
+        echo "Error: no local image ${ARM64_IMG}"
+        echo "Build first, or retag your image:"
+        echo "  docker tag <your-image-id> ${ARM64_IMG}"
+        exit 1
+    fi
+    docker push "${ARM64_IMG}"
+else
+    echo "Building and pushing jupyter-datascience-arm64 (altastata ${ALTASTATA_PYPI_VERSION})..."
+    docker build -f containers/jupyter/Dockerfile.arm64 \
+        --build-arg ALTASTATA_VERSION=${ALTASTATA_PYPI_VERSION} \
+        -t "${ARM64_IMG}" . && \
+        docker push "${ARM64_IMG}"
+fi
+
+if [[ "${PUSH_JUPYTER_AMD64_TO_GHCR:-}" == "1" ]]; then
+    echo ""
+    echo "Building and pushing jupyter-datascience-amd64 (altastata ${ALTASTATA_PYPI_VERSION})..."
+    docker buildx build --platform linux/amd64 --file containers/jupyter/Dockerfile.amd64 \
+        --build-arg ALTASTATA_VERSION=${ALTASTATA_PYPI_VERSION} \
+        --tag ghcr.io/sergevil/altastata/jupyter-datascience-amd64:${VERSION} \
+        --push .
+fi
 
 echo ""
-echo "✅ Images pushed successfully to GHCR!"
+echo "✅ Push to GHCR finished."
 echo ""
-echo "Images available at:"
+echo "Images:"
 echo "- ghcr.io/sergevil/altastata/jupyter-datascience-arm64:${VERSION}"
-echo "- ghcr.io/sergevil/altastata/jupyter-datascience-amd64:${VERSION}"
+if [[ "${PUSH_JUPYTER_AMD64_TO_GHCR:-}" == "1" ]]; then
+    echo "- ghcr.io/sergevil/altastata/jupyter-datascience-amd64:${VERSION}"
+fi
 echo ""
 
-echo "To deploy from GHCR, pull the image for your platform:"
+echo "Pull:"
 echo "  ARM64 (Apple Silicon): docker pull ghcr.io/sergevil/altastata/jupyter-datascience-arm64:${VERSION}"
-echo "  AMD64:                 docker pull ghcr.io/sergevil/altastata/jupyter-datascience-amd64:${VERSION}"
+if [[ "${PUSH_JUPYTER_AMD64_TO_GHCR:-}" == "1" ]]; then
+    echo "  AMD64:                 docker pull ghcr.io/sergevil/altastata/jupyter-datascience-amd64:${VERSION}"
+fi

--- a/containers/jupyter/push-to-ghcr.sh
+++ b/containers/jupyter/push-to-ghcr.sh
@@ -15,6 +15,10 @@ if [ -z "$VERSION" ]; then
     echo "Please ensure version.sh contains: VERSION=\"your_version\""
     exit 1
 fi
+if [ -z "$ALTASTATA_PYPI_VERSION" ]; then
+    echo "Error: ALTASTATA_PYPI_VERSION not extracted from setup.py (see version.sh)"
+    exit 1
+fi
 
 # Check if GitHub token is set
 if [ -z "$GITHUB_TOKEN" ]; then
@@ -40,14 +44,17 @@ echo ""
 cd "$REPO_ROOT"
 
 # Build and push jupyter-datascience-arm64
-echo "Building and pushing jupyter-datascience-arm64..."
-docker build -f containers/jupyter/Dockerfile.arm64 -t ghcr.io/sergevil/altastata/jupyter-datascience-arm64:${VERSION} . && \
+echo "Building and pushing jupyter-datascience-arm64 (altastata ${ALTASTATA_PYPI_VERSION})..."
+docker build -f containers/jupyter/Dockerfile.arm64 \
+    --build-arg ALTASTATA_VERSION=${ALTASTATA_PYPI_VERSION} \
+    -t ghcr.io/sergevil/altastata/jupyter-datascience-arm64:${VERSION} . && \
     docker push ghcr.io/sergevil/altastata/jupyter-datascience-arm64:${VERSION}
 
 # Build and push jupyter-datascience-amd64
 echo ""
-echo "Building and pushing jupyter-datascience-amd64..."
+echo "Building and pushing jupyter-datascience-amd64 (altastata ${ALTASTATA_PYPI_VERSION})..."
 docker buildx build --platform linux/amd64 --file containers/jupyter/Dockerfile.amd64 \
+    --build-arg ALTASTATA_VERSION=${ALTASTATA_PYPI_VERSION} \
     --tag ghcr.io/sergevil/altastata/jupyter-datascience-amd64:${VERSION} \
     --push .
 

--- a/containers/jupyter/requirements-ibm.txt
+++ b/containers/jupyter/requirements-ibm.txt
@@ -1,8 +1,9 @@
 # Jupyter DataScience Environment
 jupyterlab
 
-# AltaStata Python Package
-altastata==0.1.23
+# AltaStata Python Package — installed in its own RUN layer in Dockerfile.s390x via
+# ARG ALTASTATA_VERSION (so a version bump invalidates only that layer). Don't add
+# altastata here or both layers fight over the version.
 
 # Additional ML/Data Science
 numpy

--- a/containers/jupyter/requirements.txt
+++ b/containers/jupyter/requirements.txt
@@ -6,8 +6,9 @@ ipywidgets
 notebook
 seaborn
 
-# AltaStata Python Package
-altastata==0.1.21
+# AltaStata Python Package — installed in its own RUN layer in Dockerfile.amd64 via
+# ARG ALTASTATA_VERSION (so a version bump invalidates only that layer). Don't add
+# altastata here or both layers fight over the version.
 
 # LangChain Ecosystem
 langchain

--- a/containers/linuxone/build-jupyter-and-rag-in-parallel.sh
+++ b/containers/linuxone/build-jupyter-and-rag-in-parallel.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Jupyter + RAG s390x Docker images — BOTH builds in parallel ON THIS MACHINE.
+# Intended for IBM Z / LinuxONE only (no Docker on Mac; no SSH from Mac).
+#
+# Prerequisites (on LinuxONE): git checkout of this repo, Docker, optionally
+#   /root/llama_models/llama-3.2-1b-instruct-be.f16.gguf when ENABLE_ZDNN=1
+#
+# From repo root (after git pull):
+#   ./containers/linuxone/build-jupyter-and-rag-in-parallel.sh
+# Or:
+#   ENABLE_ZDNN=1 ./containers/linuxone/build-jupyter-and-rag-in-parallel.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+ENABLE_ZDNN="${ENABLE_ZDNN:-0}"
+F16_FILE="llama-3.2-1b-instruct-be.f16.gguf"
+RAG_MODEL_PATH="containers/rag-example/$F16_FILE"
+
+source ./version.sh
+
+if [ "$ENABLE_ZDNN" = "1" ]; then
+  if [ ! -f "/root/llama_models/$F16_FILE" ]; then
+    echo "ERROR: /root/llama_models/$F16_FILE missing (needed for ENABLE_ZDNN=1)." >&2
+    exit 2
+  fi
+  ln -f "/root/llama_models/$F16_FILE" "$RAG_MODEL_PATH" 2>/dev/null \
+    || cp -f "/root/llama_models/$F16_FILE" "$RAG_MODEL_PATH"
+else
+  : >"$RAG_MODEL_PATH"
+fi
+
+echo "parallel: Jupyter (jupyter-datascience-s390x) ..."
+docker build --build-arg ALTASTATA_VERSION="$ALTASTATA_PYPI_VERSION" \
+  -f containers/jupyter/Dockerfile.s390x \
+  -t altastata/jupyter-datascience-s390x:latest \
+  -t "altastata/jupyter-datascience-s390x:${JUPYTER_VERSION}" . &
+PID_J=$!
+
+echo "parallel: RAG (rag-open-llm-s390x) ..."
+if [ "$ENABLE_ZDNN" = "1" ]; then
+  RAG_TAGS="-t altastata/rag-open-llm-s390x:${RAG_VERSION}_zdnn"
+else
+  RAG_TAGS="-t altastata/rag-open-llm-s390x:latest -t altastata/rag-open-llm-s390x:${RAG_VERSION}"
+fi
+# shellcheck disable=SC2086
+docker build --build-arg ENABLE_ZDNN="$ENABLE_ZDNN" \
+  -f containers/rag-example/Dockerfile.open_llm_s390x \
+  ${RAG_TAGS} . &
+PID_R=$!
+
+ej=0
+er=0
+wait "$PID_J" || ej=$?
+wait "$PID_R" || er=$?
+
+if [ "$ej" -ne 0 ]; then echo "Jupyter docker build exited $ej" >&2; fi
+if [ "$er" -ne 0 ]; then echo "RAG docker build exited $er" >&2; fi
+
+if [ "$ej" -ne 0 ]; then exit "$ej"; fi
+if [ "$er" -ne 0 ]; then exit "$er"; fi
+echo "Both builds finished OK."

--- a/containers/linuxone/build-jupyter-and-rag-on-linuxone.sh
+++ b/containers/linuxone/build-jupyter-and-rag-on-linuxone.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 # Jupyter then RAG s390x Docker images on THIS MACHINE (LinuxONE / s390x only).
 #
-# Prerequisites: git checkout, Docker, optionally
-#   /root/llama_models/llama-3.2-1b-instruct-be.f16.gguf when ENABLE_ZDNN=1
+# This is the build entrypoint ON the VM — do NOT run containers/build-s390x-jupyter-and-rag-on-server.sh
+# here (that script is workstation-only: SSH + rsync, then invokes this runner remotely).
 #
-# From repo root (after git pull):
+# Prerequisites: synced repo tree on this VM (typically rsync from Mac; git on VM not required),
+#   Docker, and optionally /root/llama_models/llama-3.2-1b-instruct-be.f16.gguf when ENABLE_ZDNN=1
+#
+# From repo root (after updating the tree on disk):
 #   ./containers/linuxone/build-jupyter-and-rag-on-linuxone.sh
 #   ENABLE_ZDNN=1 ./containers/linuxone/build-jupyter-and-rag-on-linuxone.sh
+# RAG only (skip Jupyter), e.g. after zDNN model change:
+#   ENABLE_ZDNN=1 SKIP_JUPYTER=1 ./containers/linuxone/build-jupyter-and-rag-on-linuxone.sh
 
 set -euo pipefail
 
@@ -14,6 +19,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$REPO_ROOT"
 
 ENABLE_ZDNN="${ENABLE_ZDNN:-0}"
+SKIP_JUPYTER="${SKIP_JUPYTER:-0}"
 F16_FILE="llama-3.2-1b-instruct-be.f16.gguf"
 RAG_MODEL_PATH="containers/rag-example/$F16_FILE"
 
@@ -30,11 +36,15 @@ else
   : >"$RAG_MODEL_PATH"
 fi
 
-echo "Building Jupyter (jupyter-datascience-s390x) ..."
-docker build --build-arg ALTASTATA_VERSION="$ALTASTATA_PYPI_VERSION" \
-  -f containers/jupyter/Dockerfile.s390x \
-  -t altastata/jupyter-datascience-s390x:latest \
-  -t "altastata/jupyter-datascience-s390x:${JUPYTER_VERSION}" .
+if [ "$SKIP_JUPYTER" = "1" ]; then
+  echo "SKIP_JUPYTER=1: skipping Jupyter image."
+else
+  echo "Building Jupyter (jupyter-datascience-s390x) ..."
+  docker build --build-arg ALTASTATA_VERSION="$ALTASTATA_PYPI_VERSION" \
+    -f containers/jupyter/Dockerfile.s390x \
+    -t altastata/jupyter-datascience-s390x:latest \
+    -t "altastata/jupyter-datascience-s390x:${JUPYTER_VERSION}" .
+fi
 
 echo "Building RAG (rag-open-llm-s390x) ..."
 if [ "$ENABLE_ZDNN" = "1" ]; then
@@ -47,4 +57,8 @@ docker build --build-arg ENABLE_ZDNN="$ENABLE_ZDNN" \
   -f containers/rag-example/Dockerfile.open_llm_s390x \
   ${RAG_TAGS} .
 
-echo "Both sequential builds finished OK."
+if [ "$SKIP_JUPYTER" = "1" ]; then
+  echo "Build finished OK (RAG image only)."
+else
+  echo "Build finished OK (Jupyter + RAG)."
+fi

--- a/containers/linuxone/build-jupyter-and-rag-on-linuxone.sh
+++ b/containers/linuxone/build-jupyter-and-rag-on-linuxone.sh
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
-# Jupyter + RAG s390x Docker images — BOTH builds in parallel ON THIS MACHINE.
-# Intended for IBM Z / LinuxONE only (no Docker on Mac; no SSH from Mac).
+# Jupyter then RAG s390x Docker images on THIS MACHINE (LinuxONE / s390x only).
 #
-# Prerequisites (on LinuxONE): git checkout of this repo, Docker, optionally
+# Prerequisites: git checkout, Docker, optionally
 #   /root/llama_models/llama-3.2-1b-instruct-be.f16.gguf when ENABLE_ZDNN=1
 #
 # From repo root (after git pull):
-#   ./containers/linuxone/build-jupyter-and-rag-in-parallel.sh
-# Or:
-#   ENABLE_ZDNN=1 ./containers/linuxone/build-jupyter-and-rag-in-parallel.sh
+#   ./containers/linuxone/build-jupyter-and-rag-on-linuxone.sh
+#   ENABLE_ZDNN=1 ./containers/linuxone/build-jupyter-and-rag-on-linuxone.sh
 
 set -euo pipefail
 
@@ -32,14 +30,13 @@ else
   : >"$RAG_MODEL_PATH"
 fi
 
-echo "parallel: Jupyter (jupyter-datascience-s390x) ..."
+echo "Building Jupyter (jupyter-datascience-s390x) ..."
 docker build --build-arg ALTASTATA_VERSION="$ALTASTATA_PYPI_VERSION" \
   -f containers/jupyter/Dockerfile.s390x \
   -t altastata/jupyter-datascience-s390x:latest \
-  -t "altastata/jupyter-datascience-s390x:${JUPYTER_VERSION}" . &
-PID_J=$!
+  -t "altastata/jupyter-datascience-s390x:${JUPYTER_VERSION}" .
 
-echo "parallel: RAG (rag-open-llm-s390x) ..."
+echo "Building RAG (rag-open-llm-s390x) ..."
 if [ "$ENABLE_ZDNN" = "1" ]; then
   RAG_TAGS="-t altastata/rag-open-llm-s390x:${RAG_VERSION}_zdnn"
 else
@@ -48,17 +45,6 @@ fi
 # shellcheck disable=SC2086
 docker build --build-arg ENABLE_ZDNN="$ENABLE_ZDNN" \
   -f containers/rag-example/Dockerfile.open_llm_s390x \
-  ${RAG_TAGS} . &
-PID_R=$!
+  ${RAG_TAGS} .
 
-ej=0
-er=0
-wait "$PID_J" || ej=$?
-wait "$PID_R" || er=$?
-
-if [ "$ej" -ne 0 ]; then echo "Jupyter docker build exited $ej" >&2; fi
-if [ "$er" -ne 0 ]; then echo "RAG docker build exited $er" >&2; fi
-
-if [ "$ej" -ne 0 ]; then exit "$ej"; fi
-if [ "$er" -ne 0 ]; then exit "$er"; fi
-echo "Both builds finished OK."
+echo "Both sequential builds finished OK."

--- a/containers/linuxone/run-jupyter-and-rag-on-server-for-browser.sh
+++ b/containers/linuxone/run-jupyter-and-rag-on-server-for-browser.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Start Jupyter + RAG s390x containers ON LinuxONE so you can test in a browser.
+# Run from repo root on your Mac *after* builds on the server (`build-s390x-jupyter-and-rag-on-server.sh`).
+# Containers keep running until you stop them (no curl smoke, no auto-remove).
+#
+# Default images (from version.sh):
+#   altastata/jupyter-datascience-s390x:${JUPYTER_VERSION}
+#   altastata/rag-open-llm-s390x:${RAG_VERSION}
+#
+# Optional env:
+#   SSH_HOST SSH_KEY ACCOUNT_NAME (RAG) RUN_JUP=0 or RUN_RAG=0 to skip one service
+#   JUPYTER_HOST_PORT (default 8888) RAG_HOST_PORT (default 8000)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=../../version.sh
+source "${REPO_ROOT}/version.sh"
+
+SSH_KEY="${SSH_KEY:-/Users/sergevilvovsky/Downloads/torontolinuxonesshkey_rsa.prv}"
+SSH_HOST="${SSH_HOST:-root@163.66.89.80}"
+SSH_OPTS="-i $SSH_KEY -o StrictHostKeyChecking=accept-new -o GSSAPIAuthentication=no -o PreferredAuthentications=publickey"
+PUBLIC_HOST="${PUBLIC_HOST:-${SSH_HOST#*@}}"
+
+REMOTE_ALTASTATA_ACCOUNTS="${REMOTE_ALTASTATA_ACCOUNTS:-/root/.altastata/accounts}"
+ACCOUNT_NAME="${ACCOUNT_NAME:-amazon.rsa.bob123}"
+REMOTE_GREP11_YAML="${REMOTE_GREP11_YAML:-/etc/ep11client/grep11client.yaml}"
+REMOTE_HPCS_DIR="${REMOTE_HPCS_DIR:-/home/jovyan/hpcs}"
+REMOTE_HPCS_BLOB="${REMOTE_HPCS_BLOB:-$REMOTE_HPCS_DIR/hpcs-privkey.blob}"
+REMOTE_PROPERTIES_FILE="${REMOTE_PROPERTIES_FILE:-$REMOTE_ALTASTATA_ACCOUNTS/$ACCOUNT_NAME/altastata-myorgrsa444-serge678.user.properties}"
+REMOTE_MODELS_DIR="${REMOTE_MODELS_DIR:-/root/llama_models}"
+
+JUP_IMG="altastata/jupyter-datascience-s390x:${JUPYTER_VERSION}"
+RAG_IMG="altastata/rag-open-llm-s390x:${RAG_VERSION}"
+
+JUP_CTR="${JUP_CTR:-altastata-jupyter-s390x-web}"
+RAG_CTR="${RAG_CTR:-rag-open-llm-s390x-web}"
+
+JUPYTER_HOST_PORT="${JUPYTER_HOST_PORT:-8888}"
+RAG_HOST_PORT="${RAG_HOST_PORT:-8000}"
+
+REMOTE_JUP_WORK="${REMOTE_JUP_WORK:-/root/jupyter-web-work}"
+
+LLM_PROVIDER="${LLM_PROVIDER:-llama-cpp}"
+QUERY_TIMEOUT="${QUERY_TIMEOUT:-400}"
+
+RUN_JUP="${RUN_JUP:-1}"
+RUN_RAG="${RUN_RAG:-1}"
+
+echo "SSH: $SSH_HOST  (browser: http://$PUBLIC_HOST:... )"
+echo "Jupyter image: $JUP_IMG  container: $JUP_CTR  port: $JUPYTER_HOST_PORT"
+echo "RAG image:     $RAG_IMG  container: $RAG_CTR  port: $RAG_HOST_PORT"
+echo "RAG account:   $REMOTE_ALTASTATA_ACCOUNTS/$ACCOUNT_NAME"
+echo ""
+
+ssh $SSH_OPTS "$SSH_HOST" "mkdir -p '$REMOTE_JUP_WORK' '$REMOTE_MODELS_DIR'" || true
+
+if [ "$RUN_JUP" = "1" ]; then
+  echo "--- Starting Jupyter (detached)"
+  ssh $SSH_OPTS "$SSH_HOST" "docker rm -f '$JUP_CTR' 2>/dev/null || true"
+  ssh $SSH_OPTS "$SSH_HOST" "docker run -d --name '$JUP_CTR' \
+    -p '${JUPYTER_HOST_PORT}:8888' \
+    -v '${REMOTE_JUP_WORK}:/home/jovyan/work' \
+    -v '/root/.altastata:/opt/app-root/src/.altastata:rw' \
+    '$JUP_IMG'"
+else
+  echo "--- Skipping Jupyter (RUN_JUP=$RUN_JUP)"
+fi
+
+if [ "$RUN_RAG" = "1" ]; then
+  HPCS_ENV=""
+  HPCS_MOUNTS=""
+  case "$ACCOUNT_NAME" in *hpcs*)
+    ssh $SSH_OPTS "$SSH_HOST" "for f in '$REMOTE_GREP11_YAML' '$REMOTE_HPCS_BLOB' '$REMOTE_PROPERTIES_FILE'; do
+      [ -f \"\$f\" ] || { echo \"Missing: \$f\"; exit 1; }; echo \"  OK \$f\"; done"
+    HPCS_ENV="-e ALTASTATA_USE_HPCS=1 -e GREP11_YAML=/etc/ep11client/grep11client.yaml -e HPCS_PRIV_KEY_BLOB_PATH=/home/jovyan/hpcs/hpcs-privkey.blob"
+    HPCS_MOUNTS="-v $REMOTE_GREP11_YAML:/etc/ep11client/grep11client.yaml:ro -v $REMOTE_HPCS_DIR:/home/jovyan/hpcs:ro"
+    ;;
+  esac
+
+  LLAMA_OPTS=""
+  [ -n "${LLAMA_CPP_MODEL_REPO+x}" ] && LLAMA_OPTS="$LLAMA_OPTS -e LLAMA_CPP_MODEL_REPO=$LLAMA_CPP_MODEL_REPO"
+  [ -n "${LLAMA_CPP_MODEL_FILE:-}" ] && LLAMA_OPTS="$LLAMA_OPTS -e LLAMA_CPP_MODEL_FILE=$LLAMA_CPP_MODEL_FILE"
+  [ -n "${HF_LLM_MODEL:-}" ]      && LLAMA_OPTS="$LLAMA_OPTS -e HF_LLM_MODEL=$HF_LLM_MODEL"
+
+  echo "--- Starting RAG (detached)"
+  ssh $SSH_OPTS "$SSH_HOST" "docker rm -f '$RAG_CTR' 2>/dev/null || true"
+  # shellcheck disable=SC2086
+  ssh $SSH_OPTS "$SSH_HOST" "docker run -d --name '$RAG_CTR' -p '${RAG_HOST_PORT}:8000' \
+    -e ALTASTATA_ACCOUNT_DIR=$REMOTE_ALTASTATA_ACCOUNTS/$ACCOUNT_NAME \
+    $HPCS_ENV \
+    -e LLM_PROVIDER=$LLM_PROVIDER \
+    -e QUERY_TIMEOUT=$QUERY_TIMEOUT \
+    $LLAMA_OPTS \
+    -v $REMOTE_ALTASTATA_ACCOUNTS:$REMOTE_ALTASTATA_ACCOUNTS:ro \
+    -v $REMOTE_MODELS_DIR:/models \
+    $HPCS_MOUNTS \
+    '$RAG_IMG'"
+else
+  echo "--- Skipping RAG (RUN_RAG=$RUN_RAG)"
+fi
+
+echo ""
+echo "===== Browser ====="
+[ "$RUN_JUP" = "1" ] && {
+  echo "Jupyter Lab:  http://$PUBLIC_HOST:$JUPYTER_HOST_PORT/"
+  echo "Get token:      ssh $SSH_OPTS $SSH_HOST \"docker exec '$JUP_CTR' jupyter server list\""
+  echo "Logs:           ssh $SSH_OPTS $SSH_HOST \"docker logs -f '$JUP_CTR'\""
+}
+[ "$RUN_RAG" = "1" ] && {
+  echo "RAG web app:   http://$PUBLIC_HOST:$RAG_HOST_PORT/"
+  echo "Logs:           ssh $SSH_OPTS $SSH_HOST \"docker logs -f '$RAG_CTR'\""
+}
+echo ""
+echo "Allow inbound 8888 / 8000 (or your ports) on the VPC security group if needed."
+echo "Stop: ssh $SSH_OPTS $SSH_HOST \"docker stop '$JUP_CTR' '$RAG_CTR'; docker rm '$JUP_CTR' '$RAG_CTR'\""
+echo " (ignore errors if only one was started)"

--- a/containers/rag-example/Dockerfile.open_llm_mac
+++ b/containers/rag-example/Dockerfile.open_llm_mac
@@ -24,8 +24,12 @@ RUN python -m pip install --upgrade pip
 COPY examples/rag-example/open_llm/requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
-# Install AltaStata from repo copy only
-COPY . /src/altastata-python-package
+# Install AltaStata from repo copy only.
+# Narrowed from `COPY . /src/altastata-python-package` so the COPY (and the pip
+# install layer below) only invalidates when the actual altastata source
+# changes — not on unrelated edits to the repo (docs, sibling Dockerfiles, etc.).
+COPY setup.py pyproject.toml README.md /src/altastata-python-package/
+COPY altastata /src/altastata-python-package/altastata
 RUN pip install --no-cache-dir /src/altastata-python-package
 
 # App code (no sample_documents; documents come from AltaStata)

--- a/containers/rag-example/Dockerfile.open_llm_s390x
+++ b/containers/rag-example/Dockerfile.open_llm_s390x
@@ -1,7 +1,9 @@
 # AltaStata RAG – Open LLM stack for IBM Z / LinuxONE (s390x)
 # Build from repo root: docker build -f containers/rag-example/Dockerfile.open_llm_s390x --platform linux/s390x .
 # Base: ibmz-accelerated-for-pytorch (optimized for PyTorch + zDNN). LLM via llama.cpp + GGUF (much faster than Transformers on CPU)
-# with OpenBLAS-vectorized inference. Uses big-endian GGUFs from https://huggingface.co/collections/taronaeo/s390x-runnable-models.
+# with OpenBLAS + VXE2 SIMD inference, plus the zDNN backend for IBM NNPA acceleration on z17 / LinuxONE 5+ (Telum II).
+# On z15/z16 hardware llama.cpp's zDNN backend reports unsupported and falls back to CPU automatically, so the same image
+# runs on every supported s390x system. Uses big-endian GGUFs from https://huggingface.co/collections/taronaeo/s390x-runnable-models.
 # Set LLM_PROVIDER=transformers to fall back to PyTorch (slower).
 
 FROM --platform=linux/s390x icr.io/ibmz/ibmz-accelerated-for-pytorch@sha256:b95591595e7ac0b9cc5219355fae61ec2a2766758f768d1d8e4937ae5d219430
@@ -12,14 +14,48 @@ LABEL org.opencontainers.image.source="https://github.com/altastata/altastata-py
 
 USER root
 
-# Java for AltaStata; build deps for sentence-transformers and llama-cpp-python (cmake + OpenBLAS + git)
+# Java for AltaStata; build deps for sentence-transformers, IBM zDNN (autotools), and llama-cpp-python (cmake + OpenBLAS + git)
 RUN dnf install -y java-17-openjdk-headless gcc gcc-c++ gcc-gfortran make \
     cmake openblas-devel git \
+    autoconf automake libtool \
     libxml2-devel libxslt-devel \
     && dnf clean all
 
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 ENV PATH="${PATH}:${JAVA_HOME}/bin"
+
+# zDNN / NNPA (z16/z17) hardware acceleration is currently *off by default* —
+# Nicolas reported that activating it via this image regresses query quality on
+# his z17 vs the CPU/VXE2 fallback (still under investigation). All zDNN-related
+# code paths remain in the Dockerfile / entrypoint, gated behind ENABLE_ZDNN so
+# we can re-enable for research with a single build-arg flip:
+#   ENABLE_ZDNN=1 ./containers/rag-example/build-rag-s390x-on-server.sh
+# Default 0 builds llama-cpp-python with CPU+VXE2 only, skips the zDNN library
+# build, and the entrypoint always picks Q5_K_S (faster than F16 on plain CPU).
+ARG ENABLE_ZDNN=0
+ENV ENABLE_ZDNN=${ENABLE_ZDNN}
+
+# Build IBM zDNN library from source so llama-cpp-python can link the zDNN backend
+# for IBM NNPA on z17 / LinuxONE 5+. Per upstream llama.cpp guidance
+# (https://github.com/ggml-org/llama.cpp/blob/master/docs/backend/zDNN.md) we build
+# from source rather than apt/yum (issue ggml-org/llama.cpp#15772). On older
+# hardware (z15/z16) the backend reports unsupported and llama.cpp falls back to
+# CPU/VXE2, so this image still runs everywhere on s390x. Cached layer.
+# Skipped when ENABLE_ZDNN=0 (saves ~2 min build time and ~50 MB layer).
+RUN if [ "$ENABLE_ZDNN" = "1" ]; then \
+        git clone --recurse-submodules https://github.com/IBM/zDNN /tmp/zDNN && \
+        cd /tmp/zDNN && \
+        autoreconf . && \
+        ./configure --prefix=/opt/zdnn-libs && \
+        make build && \
+        make install && \
+        rm -rf /tmp/zDNN && \
+        echo '/opt/zdnn-libs/lib' > /etc/ld.so.conf.d/zdnn.conf && \
+        ldconfig ; \
+    else \
+        echo "ENABLE_ZDNN=0; skipping IBM zDNN build (CPU/VXE2 path only)." ; \
+    fi
+ENV ZDNN_ROOT=/opt/zdnn-libs
 
 WORKDIR /app
 
@@ -31,12 +67,66 @@ RUN python -m pip install --upgrade pip
 COPY examples/rag-example/open_llm/requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
-# llama-cpp-python: native s390x build with OpenBLAS for CPU inference. Cached layer; rebuilds only when this RUN line or the base layers change.
-RUN CMAKE_ARGS="-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS" \
-    pip install --no-cache-dir llama-cpp-python huggingface_hub
+# llama-cpp-python: native s390x build with OpenBLAS (CPU + VXE2 SIMD on z15+) AND
+# (when ENABLE_ZDNN=1) zDNN backend for IBM NNPA acceleration on z17 / LinuxONE 5+
+# (Telum II). On older hardware the zDNN ops are unavailable and llama.cpp falls back
+# to CPU automatically, so the zDNN-enabled image runs everywhere on s390x.
+# Default build is CPU/VXE2 only (no zDNN cmake flag) — re-enable for research:
+#   docker build --build-arg ENABLE_ZDNN=1 ...
+RUN if [ "$ENABLE_ZDNN" = "1" ]; then \
+        echo "Building llama-cpp-python with zDNN backend (NNPA on z16/z17)" ; \
+        CMAKE_ARGS="-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS -DGGML_ZDNN=ON -DZDNN_ROOT=/opt/zdnn-libs" \
+            pip install --no-cache-dir llama-cpp-python huggingface_hub ; \
+    else \
+        echo "Building llama-cpp-python with CPU/VXE2 only (zDNN disabled)" ; \
+        CMAKE_ARGS="-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS" \
+            pip install --no-cache-dir llama-cpp-python huggingface_hub ; \
+    fi
 
-# Install AltaStata from repo copy only (do not also pip install altastata from PyPI – would conflict)
-COPY . /src/altastata-python-package
+# Fix-up: llama-cpp-python's wheel install only copies the backends it knows about
+# (cpu/blas/base) into llama_cpp/lib/, which is the only directory libllama.so
+# searches via RPATH=$ORIGIN. New backends (zDNN, plus llama-common/mtmd helpers)
+# get installed under .../site-packages/lib64/ and are missed at import time:
+#   OSError: libggml-zdnn.so.0: cannot open shared object file
+# Copy the orphaned shared libs into the loader's search path so llama_cpp imports
+# cleanly with the zDNN backend registered. Only relevant when ENABLE_ZDNN=1.
+RUN if [ "$ENABLE_ZDNN" = "1" ]; then \
+        PYLIB=$(python -c "import sys, os; print(next(p for p in sys.path if p.endswith('site-packages')))") && \
+        if [ -d "$PYLIB/lib64" ]; then \
+            cp -fv "$PYLIB"/lib64/libggml-zdnn* "$PYLIB"/llama_cpp/lib/ 2>/dev/null || true ; \
+            cp -fv "$PYLIB"/lib64/libllama-common* "$PYLIB"/llama_cpp/lib/ 2>/dev/null || true ; \
+            cp -fv "$PYLIB"/lib64/libmtmd* "$PYLIB"/llama_cpp/lib/ 2>/dev/null || true ; \
+        fi && \
+        ls -la "$PYLIB/llama_cpp/lib/" | grep -E '\.so' ; \
+    fi && \
+    python -c "import llama_cpp; print('llama-cpp-python', llama_cpp.__version__, 'imported OK')"
+
+# Bake the self-converted F16 big-endian Llama-3.2-1B GGUF into /opt/models so
+# the entrypoint can pick it up on z16 / z17 (NNPA -> zDNN acceleration) without
+# any host-side scp or runtime HF download. /opt/models is intentionally NOT
+# declared as a VOLUME below so the bundled file survives even when callers
+# mount their own host dir at /models. The entrypoint prefers /models (volume,
+# user-supplied F16 wins) and falls back to /opt/models.
+#
+# The file must be staged into the build context at
+# containers/rag-example/llama-3.2-1b-instruct-be.f16.gguf
+# by build-rag-s390x-on-server.sh; it is .gitignore'd (~2.5 GB, never commit).
+# When ENABLE_ZDNN=0 (the default) the build script stages a tiny placeholder
+# at the same path so this COPY always succeeds; the next RUN deletes it so
+# /opt/models is empty and the entrypoint always falls back to Q5_K_S.
+COPY containers/rag-example/llama-3.2-1b-instruct-be.f16.gguf /opt/models/llama-3.2-1b-instruct-be.f16.gguf
+RUN if [ "$ENABLE_ZDNN" != "1" ]; then \
+        echo "ENABLE_ZDNN=0; removing /opt/models/*.f16.gguf placeholder (F16 only useful with zDNN)." && \
+        rm -f /opt/models/*.f16.gguf ; \
+    else \
+        ls -la /opt/models/ ; \
+    fi
+
+# Install AltaStata from repo copy only (do not also pip install altastata from PyPI – would conflict).
+# Narrowed from `COPY . /src/altastata-python-package` so the 2.5 GB F16 GGUF
+# in the build context is not duplicated into a second layer.
+COPY setup.py pyproject.toml README.md /src/altastata-python-package/
+COPY altastata /src/altastata-python-package/altastata
 RUN pip install --no-cache-dir /src/altastata-python-package
 
 # App code (no sample_documents; documents come from AltaStata — run indexer to populate)

--- a/containers/rag-example/Dockerfile.open_llm_s390x
+++ b/containers/rag-example/Dockerfile.open_llm_s390x
@@ -1,6 +1,8 @@
 # AltaStata RAG – Open LLM stack for IBM Z / LinuxONE (s390x)
 # Build from repo root: docker build -f containers/rag-example/Dockerfile.open_llm_s390x --platform linux/s390x .
-# Base: ibmz-accelerated-for-pytorch (optimized for PyTorch + zDNN). For compiled LLM inference see icr.io/ibmz/zdlc (ONNX); for Python+Transformers this is the right base. No ibmz image has both PyTorch and scikit-learn, so we build scikit-learn (cached). LLM via Transformers (TinyLlama) on CPU; use NNPA-capable host for better speed.
+# Base: ibmz-accelerated-for-pytorch (optimized for PyTorch + zDNN). LLM via llama.cpp + GGUF (much faster than Transformers on CPU)
+# with OpenBLAS-vectorized inference. Uses big-endian GGUFs from https://huggingface.co/collections/taronaeo/s390x-runnable-models.
+# Set LLM_PROVIDER=transformers to fall back to PyTorch (slower).
 
 FROM --platform=linux/s390x icr.io/ibmz/ibmz-accelerated-for-pytorch@sha256:b95591595e7ac0b9cc5219355fae61ec2a2766758f768d1d8e4937ae5d219430
 
@@ -10,8 +12,9 @@ LABEL org.opencontainers.image.source="https://github.com/altastata/altastata-py
 
 USER root
 
-# Java and build deps for AltaStata and sentence-transformers (same pattern as Dockerfile.s390x)
+# Java for AltaStata; build deps for sentence-transformers and llama-cpp-python (cmake + OpenBLAS + git)
 RUN dnf install -y java-17-openjdk-headless gcc gcc-c++ gcc-gfortran make \
+    cmake openblas-devel git \
     libxml2-devel libxslt-devel \
     && dnf clean all
 
@@ -27,6 +30,10 @@ RUN python -m pip install --upgrade pip
 # Base image is PyTorch+zDNN only; pip builds scikit-learn here once, then cached.
 COPY examples/rag-example/open_llm/requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
+
+# llama-cpp-python: native s390x build with OpenBLAS for CPU inference. Cached layer; rebuilds only when this RUN line or the base layers change.
+RUN CMAKE_ARGS="-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS" \
+    pip install --no-cache-dir llama-cpp-python huggingface_hub
 
 # Install AltaStata from repo copy only (do not also pip install altastata from PyPI – would conflict)
 COPY . /src/altastata-python-package
@@ -44,10 +51,13 @@ ENV WEB_HOST=0.0.0.0
 ENV WEB_PORT=8000
 ENV VECTOR_STORE=simple
 ENV LOCAL_INDEX_PATH=/app/open_llm/local_index
-# Force Transformers on s390x (no MLX; Ollama optional if built from source)
-ENV LLM_PROVIDER=transformers
+# Default LLM provider on s390x: llama.cpp + big-endian GGUF (much faster than Transformers on CPU).
+# Override at run time: -e LLM_PROVIDER=transformers (or watsonx) for the alternatives.
+ENV LLM_PROVIDER=llama-cpp
+ENV LLAMA_CPP_MODEL_DIR=/models
 
 VOLUME /app/open_llm/local_index
+VOLUME /models
 EXPOSE 8000
 
 WORKDIR /app/open_llm

--- a/containers/rag-example/Dockerfile.open_llm_s390x
+++ b/containers/rag-example/Dockerfile.open_llm_s390x
@@ -25,8 +25,8 @@ ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 ENV PATH="${PATH}:${JAVA_HOME}/bin"
 
 # zDNN / NNPA (z16/z17) hardware acceleration is currently *off by default* —
-# Nicolas reported that activating it via this image regresses query quality on
-# his z17 vs the CPU/VXE2 fallback (still under investigation). All zDNN-related
+# field testing on z17 showed activating it via this image regresses query
+# quality vs the CPU/VXE2 fallback (still under investigation). All zDNN-related
 # code paths remain in the Dockerfile / entrypoint, gated behind ENABLE_ZDNN so
 # we can re-enable for research with a single build-arg flip:
 #   ENABLE_ZDNN=1 ./containers/rag-example/build-rag-s390x-on-server.sh

--- a/containers/rag-example/build-and-run-rag-mac.sh
+++ b/containers/rag-example/build-and-run-rag-mac.sh
@@ -58,6 +58,10 @@ fi
 if [ "${LLM_PROVIDER:-}" = "ollama" ]; then
   RUN_OPTS+=(-e "OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}")
   [ -n "${OLLAMA_MODEL:-}" ] && RUN_OPTS+=(-e "OLLAMA_MODEL=$OLLAMA_MODEL")
+  # Generation-length cap. config.py default is 512 (was 128 — 128 truncates
+  # multi-item answers like "What are the password requirements?" mid-list).
+  # Override per-run if needed: OLLAMA_NUM_PREDICT=1024 ./build-and-run-rag-mac.sh
+  [ -n "${OLLAMA_NUM_PREDICT:-}" ] && RUN_OPTS+=(-e "OLLAMA_NUM_PREDICT=$OLLAMA_NUM_PREDICT")
 fi
 [ -n "${HF_LLM_MODEL:-}" ] && RUN_OPTS+=(-e "HF_LLM_MODEL=$HF_LLM_MODEL")
 [ -n "${RAG_INDEX_PATH:-}" ] && RUN_OPTS+=(-e "RAG_INDEX_PATH=$RAG_INDEX_PATH")

--- a/containers/rag-example/build-and-run-rag-mac.sh
+++ b/containers/rag-example/build-and-run-rag-mac.sh
@@ -57,6 +57,7 @@ fi
 # Ollama on host = much faster (Metal). Run: ollama run smollm2:360m  then use LLM_PROVIDER=ollama
 if [ "${LLM_PROVIDER:-}" = "ollama" ]; then
   RUN_OPTS+=(-e "OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}")
+  [ -n "${OLLAMA_MODEL:-}" ] && RUN_OPTS+=(-e "OLLAMA_MODEL=$OLLAMA_MODEL")
 fi
 [ -n "${HF_LLM_MODEL:-}" ] && RUN_OPTS+=(-e "HF_LLM_MODEL=$HF_LLM_MODEL")
 [ -n "${RAG_INDEX_PATH:-}" ] && RUN_OPTS+=(-e "RAG_INDEX_PATH=$RAG_INDEX_PATH")

--- a/containers/rag-example/build-llama32-1b-f16-be-gguf.sh
+++ b/containers/rag-example/build-llama32-1b-f16-be-gguf.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Self-convert unsloth/Llama-3.2-1B-Instruct-F16.gguf (little-endian) to a
+# big-endian copy that runs on s390x AND is eligible for the llama.cpp zDNN
+# backend (NNPA acceleration on z16 / z17). zDNN only accelerates F32/F16/BF16
+# datatypes (per https://github.com/taronaeo/llama.cpp-s390x/blob/master/docs/backend/zDNN.md);
+# the default Q5_K_S BE GGUF baked into our image runs fine on s390x but never
+# touches the NNPA. As of writing no F16 BE GGUFs are published on HF, so we
+# byte-swap an existing LE F16 GGUF locally.
+#
+# Run on Mac (or any LE host); the resulting BE F16 file is portable and the
+# same file works on z15 (CPU fallback, slower than Q5_K_S), z16/z17 (NNPA).
+#
+# Prereqs: python3 (>=3.9), ~6 GB free disk (~2.5 GB LE source + ~2.5 GB BE
+# output + working space). One-time pip install of huggingface_hub and gguf
+# into a venv inside $OUT_DIR (no system-wide changes).
+#
+# Usage:
+#   ./containers/rag-example/build-llama32-1b-f16-be-gguf.sh
+#   OUT_DIR=$HOME/llama_models ./containers/rag-example/build-llama32-1b-f16-be-gguf.sh
+#
+# Optional overrides (env):
+#   OUT_DIR    Where to keep both files (default: $HOME/llama_models)
+#   SRC_REPO   HF repo holding the LE F16 GGUF (default: unsloth/Llama-3.2-1B-Instruct-GGUF)
+#   SRC_FILE   File name in that repo                (default: Llama-3.2-1B-Instruct-F16.gguf)
+#   OUT_FILE   Final BE file name (matches the entrypoint NNPA auto-detect logic):
+#                                                    (default: llama-3.2-1b-instruct-be.f16.gguf)
+
+set -euo pipefail
+
+SRC_REPO="${SRC_REPO:-unsloth/Llama-3.2-1B-Instruct-GGUF}"
+SRC_FILE="${SRC_FILE:-Llama-3.2-1B-Instruct-F16.gguf}"
+OUT_DIR="${OUT_DIR:-$HOME/llama_models}"
+OUT_FILE="${OUT_FILE:-llama-3.2-1b-instruct-be.f16.gguf}"
+
+mkdir -p "$OUT_DIR"
+cd "$OUT_DIR"
+
+echo "==> Output dir: $OUT_DIR"
+echo "==> Source:     $SRC_REPO/$SRC_FILE"
+echo "==> Target:     $OUT_FILE"
+
+if [ ! -x ".venv/bin/python" ]; then
+  echo "==> Creating venv at $OUT_DIR/.venv"
+  python3 -m venv .venv
+fi
+# shellcheck disable=SC1091
+source .venv/bin/activate
+python -m pip install --quiet --upgrade pip
+python -m pip install --quiet --upgrade "huggingface_hub" "gguf"
+
+if [ ! -f "$SRC_FILE" ]; then
+  echo "==> Downloading $SRC_FILE (~2.5 GB) ..."
+  python - <<PY
+from huggingface_hub import hf_hub_download
+hf_hub_download(repo_id="$SRC_REPO", filename="$SRC_FILE", local_dir="$OUT_DIR")
+PY
+else
+  echo "==> Reusing cached $SRC_FILE"
+fi
+
+echo "==> Copying $SRC_FILE -> $OUT_FILE"
+cp -f "$SRC_FILE" "$OUT_FILE"
+
+echo "==> Byte-swapping $OUT_FILE to big-endian (rewrites in place; ~2.5 GB I/O) ..."
+echo "YES" | python -m gguf.scripts.gguf_convert_endian "$OUT_FILE" big
+
+echo "==> Verifying $OUT_FILE is big-endian ..."
+python -m gguf.scripts.gguf_convert_endian --dry-run "$OUT_FILE" big
+
+echo
+echo "Done."
+ls -la "$OUT_DIR/$OUT_FILE"
+
+cat <<EOF
+
+To deploy on LinuxONE with auto-detect (z16/z17 → F16+zDNN, z15 → Q5_K_S):
+
+  # One-time: scp the BE F16 to the GGUF cache on the LinuxONE host
+  scp "$OUT_DIR/$OUT_FILE" root@<server>:/root/llama_models/$OUT_FILE
+
+  # Then just run the existing pull-and-run script. The container's entrypoint
+  # auto-picks F16 when /proc/cpuinfo reports nnpa AND the file is in /models;
+  # otherwise it falls back to Q5_K_S.
+  ./containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
+
+To force F16 even on z15 (smoke test, slower than Q5_K_S):
+
+  LLAMA_CPP_MODEL_REPO= LLAMA_CPP_MODEL_FILE=$OUT_FILE \\
+    ./containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
+EOF

--- a/containers/rag-example/build-rag-s390x-on-server.sh
+++ b/containers/rag-example/build-rag-s390x-on-server.sh
@@ -118,18 +118,17 @@ fi
 # default tag would get the heavier image with the known z17 quality regression.
 source "$REPO_ROOT/version.sh"
 if [ "$ENABLE_ZDNN" = "1" ]; then
-  # \${RAG_VERSION}_zdnn -> remote shell expands after `source version.sh`,
-  # then literally appends _zdnn (braces required so _zdnn isn't read as
-  # part of the variable name).
+  # Remote expands RAG_VERSION after sourcing version.sh; ${_zdnn} suffix is appended on the remote shell only.
+  # Use \${VAR} below so TAG_ARGS is built locally with a literal dollar for SSH to expand.
   TAG_ARGS="-t altastata/rag-open-llm-s390x:\${RAG_VERSION}_zdnn"
   TAG_REPORT="altastata/rag-open-llm-s390x:${RAG_VERSION}_zdnn"
 else
-  TAG_ARGS="-t altastata/rag-open-llm-s390x:latest -t altastata/rag-open-llm-s390x:\$RAG_VERSION"
-  TAG_REPORT="altastata/rag-open-llm-s390x:$RAG_VERSION (and :latest)"
+  TAG_ARGS="-t altastata/rag-open-llm-s390x:latest -t altastata/rag-open-llm-s390x:\${RAG_VERSION}"
+  TAG_REPORT="altastata/rag-open-llm-s390x:${RAG_VERSION} and :latest"
 fi
-echo "Building image on server (tags: $TAG_REPORT, ENABLE_ZDNN=$ENABLE_ZDNN)..."
+echo "Building image on server — tags=${TAG_REPORT} ENABLE_ZDNN=${ENABLE_ZDNN}"
 ssh $SSH_OPTS "$SSH_HOST" "cd $REMOTE_DIR && source version.sh && docker build --build-arg ENABLE_ZDNN=$ENABLE_ZDNN -f containers/rag-example/Dockerfile.open_llm_s390x $TAG_ARGS ."
 
 echo "Done. Image $TAG_REPORT is on the server."
-echo "Accounts (if synced) are under $REMOTE_ALTASTATA_ACCOUNTS. Run with:"
+echo "Accounts — if synced — are under $REMOTE_ALTASTATA_ACCOUNTS. Run with:"
 echo "  docker run -p 8000:8000 -e ALTASTATA_ACCOUNT_DIR=$REMOTE_ALTASTATA_ACCOUNTS/amazon.rsa.bob123 -v $REMOTE_ALTASTATA_ACCOUNTS:$REMOTE_ALTASTATA_ACCOUNTS:ro ... $TAG_REPORT"

--- a/containers/rag-example/build-rag-s390x-on-server.sh
+++ b/containers/rag-example/build-rag-s390x-on-server.sh
@@ -10,6 +10,12 @@
 # If SSH does not connect: check (1) you're on a network that can reach the server (VPN, firewall),
 # (2) SSH_HOST and SSH_KEY are correct, (3) server is up and sshd is running. Test with:
 #   ssh -i "$SSH_KEY" $SSH_HOST "echo ok"
+#
+# If your Mac reports exit 137 / "Killed: 9" on the ssh line: the *local* SSH client was
+# SIGKILL'd—often memory pressure on the Mac when another heavy Docker build runs in parallel,
+# or the IDE closing the session. Fix: run only this build (pause other local Docker work), or
+# SSH to LinuxONE and run the same `docker build ...` inside tmux so losing the Mac session
+# does not cancel the server-side build.
 
 set -e
 # Repo root = directory that contains containers/ and examples/rag-example/ (altastata-python-package)

--- a/containers/rag-example/build-rag-s390x-on-server.sh
+++ b/containers/rag-example/build-rag-s390x-on-server.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# Build the RAG open_llm s390x image ON the LinuxONE server.
-# Run from repo root on your Mac (with the SSH key and server reachable).
+# Build the RAG open_llm s390x image on LinuxONE by rsync + ssh from your **workstation** (Mac).
+# If you are already **on** the LinuxONE VM with the repo tree on disk, do NOT use this script —
+# run from repo root:
+#   ENABLE_ZDNN=1 ./containers/linuxone/build-jupyter-and-rag-on-linuxone.sh
+# (Optionally SKIP_JUPYTER=1 to build only RAG.)
 #
-# Usage:
+# Usage (from Mac):
 #   ./containers/rag-example/build-rag-s390x-on-server.sh
 # Or with custom host/key:
 #   SSH_KEY=~/.ssh/my.key SSH_HOST=user@10.0.0.1 ./containers/rag-example/build-rag-s390x-on-server.sh
@@ -18,6 +21,15 @@
 # does not cancel the server-side build.
 
 set -e
+
+if [ "${SKIP_S390X_WORKSTATION_CHECK:-}" != "1" ] && command -v uname >/dev/null 2>&1 && [ "$(uname -m)" = "s390x" ]; then
+  echo "$(basename "$0"): this script rsync + SSH FROM a workstation; you are ON s390x." >&2
+  echo "On LinuxONE, from repo root run:" >&2
+  echo "  ENABLE_ZDNN=1 ./containers/linuxone/build-jupyter-and-rag-on-linuxone.sh" >&2
+  echo "(Optional: SKIP_JUPYTER=1 for RAG only.) Override: SKIP_S390X_WORKSTATION_CHECK=1" >&2
+  exit 2
+fi
+
 # Repo root = directory that contains containers/ and examples/rag-example/ (altastata-python-package)
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 SSH_KEY="${SSH_KEY:-/Users/sergevilvovsky/Downloads/torontolinuxonesshkey_rsa.prv}"

--- a/containers/rag-example/build-rag-s390x-on-server.sh
+++ b/containers/rag-example/build-rag-s390x-on-server.sh
@@ -20,6 +20,7 @@ SSH_HOST="${SSH_HOST:-root@163.66.89.80}"
 SSH_OPTS="-i $SSH_KEY -o StrictHostKeyChecking=accept-new -o GSSAPIAuthentication=no -o PreferredAuthentications=publickey"
 REMOTE_DIR="${REMOTE_DIR:-/tmp/altastata-python-package}"
 REMOTE_ALTASTATA_ACCOUNTS="${REMOTE_ALTASTATA_ACCOUNTS:-/root/.altastata/accounts}"
+REMOTE_HPCS_DIR="${REMOTE_HPCS_DIR:-/home/jovyan/hpcs}"
 # Local AltaStata accounts to copy for testing (set ALTASTATA_ACCOUNTS="" to skip)
 ALTASTATA_ACCOUNTS="${ALTASTATA_ACCOUNTS:-$HOME/.altastata/accounts/amazon.rsa.bob123 $HOME/.altastata/accounts/amazon.rsa.hpcs.serge678}"
 
@@ -42,6 +43,12 @@ if [ -n "$ALTASTATA_ACCOUNTS" ]; then
   # On server: strip hpcs-yaml-path and hpcs-priv-key-blob-path from *.user.properties so container uses GREP11_YAML / HPCS_PRIV_KEY_BLOB_PATH from env
   echo "Stripping HPCS path lines from account *.user.properties on server..."
   ssh $SSH_OPTS "$SSH_HOST" "for f in $REMOTE_ALTASTATA_ACCOUNTS/*/*.user.properties; do [ -f \"\$f\" ] && sed -i '/^hpcs-yaml-path=/d' \"\$f\" && sed -i '/^hpcs-priv-key-blob-path=/d' \"\$f\" && echo \"  \$(basename \"\$f\")\"; done"
+  HPCS_BLOB_SRC="$HOME/.altastata/accounts/amazon.rsa.hpcs.serge678/hpcs-privkey.blob"
+  if [ -f "$HPCS_BLOB_SRC" ]; then
+    echo "Copying HPCS key blob to server ($REMOTE_HPCS_DIR/hpcs-privkey.blob)..."
+    ssh $SSH_OPTS "$SSH_HOST" "mkdir -p $REMOTE_HPCS_DIR"
+    rsync -avz -e "ssh $SSH_OPTS" "$HPCS_BLOB_SRC" "$SSH_HOST:$REMOTE_HPCS_DIR/hpcs-privkey.blob"
+  fi
 fi
 
 echo "Syncing repo to server..."

--- a/containers/rag-example/build-rag-s390x-on-server.sh
+++ b/containers/rag-example/build-rag-s390x-on-server.sh
@@ -72,10 +72,43 @@ else
   echo "Skipping $HPCS_PROPERTIES_FILE (not in repo). Ensure it exists on server at $REMOTE_ALTASTATA_ACCOUNTS/$HPCS_ACCOUNT/ if using HPCS."
 fi
 
+# zDNN / NNPA hardware acceleration is OFF by default (ENABLE_ZDNN=0); see
+# Dockerfile.open_llm_s390x for the why. The Dockerfile still has a `COPY
+# containers/rag-example/llama-3.2-1b-instruct-be.f16.gguf ...` line that runs
+# unconditionally, so we always need a file at that path in the build context.
+# When ENABLE_ZDNN=1 we stage the real ~2.5 GB F16 BE GGUF (Dockerfile keeps it,
+# entrypoint can pick it). When ENABLE_ZDNN=0 we stage a 1-byte placeholder
+# and the Dockerfile's next RUN deletes it from /opt/models.
+ENABLE_ZDNN="${ENABLE_ZDNN:-0}"
+F16_FILE="llama-3.2-1b-instruct-be.f16.gguf"
+if [ "$ENABLE_ZDNN" = "1" ]; then
+  echo "ENABLE_ZDNN=1: staging real $F16_FILE from /root/llama_models/ into build context..."
+  ssh $SSH_OPTS "$SSH_HOST" "
+    if [ ! -f /root/llama_models/$F16_FILE ]; then
+      echo 'ERROR: /root/llama_models/$F16_FILE missing on server.'
+      echo 'Build (once) on Mac and scp:'
+      echo '  ./containers/rag-example/build-llama32-1b-f16-be-gguf.sh'
+      echo '  scp ~/llama_models/$F16_FILE $SSH_HOST:/root/llama_models/'
+      exit 2
+    fi
+    # Hard-link if same filesystem (fast, no extra disk); else copy. The file
+    # is 2.5 GB so we want to avoid a full copy on every rebuild.
+    ln -f /root/llama_models/$F16_FILE $REMOTE_DIR/containers/rag-example/$F16_FILE 2>/dev/null \
+      || cp -f /root/llama_models/$F16_FILE $REMOTE_DIR/containers/rag-example/$F16_FILE
+    ls -la $REMOTE_DIR/containers/rag-example/$F16_FILE
+  "
+else
+  echo "ENABLE_ZDNN=0: staging tiny placeholder for $F16_FILE (Dockerfile will delete it from /opt/models)."
+  ssh $SSH_OPTS "$SSH_HOST" "
+    : > $REMOTE_DIR/containers/rag-example/$F16_FILE
+    ls -la $REMOTE_DIR/containers/rag-example/$F16_FILE
+  "
+fi
+
 # Use same VERSION as Jupyter (version.sh)
 source "$REPO_ROOT/version.sh"
-echo "Building image on server (tag: $VERSION)..."
-ssh $SSH_OPTS "$SSH_HOST" "cd $REMOTE_DIR && source version.sh && docker build -f containers/rag-example/Dockerfile.open_llm_s390x -t altastata/rag-open-llm-s390x:latest -t altastata/rag-open-llm-s390x:\$VERSION ."
+echo "Building image on server (tag: $VERSION, ENABLE_ZDNN=$ENABLE_ZDNN)..."
+ssh $SSH_OPTS "$SSH_HOST" "cd $REMOTE_DIR && source version.sh && docker build --build-arg ENABLE_ZDNN=$ENABLE_ZDNN -f containers/rag-example/Dockerfile.open_llm_s390x -t altastata/rag-open-llm-s390x:latest -t altastata/rag-open-llm-s390x:\$VERSION ."
 
 echo "Done. Image altastata/rag-open-llm-s390x:$VERSION (and :latest) is on the server."
 echo "Accounts (if synced) are under $REMOTE_ALTASTATA_ACCOUNTS. Run with:"

--- a/containers/rag-example/build-rag-s390x-on-server.sh
+++ b/containers/rag-example/build-rag-s390x-on-server.sh
@@ -105,11 +105,25 @@ else
   "
 fi
 
-# Use same VERSION as Jupyter (version.sh)
+# Tagging strategy (RAG_VERSION comes from version.sh, currently 2026g_latest):
+#   ENABLE_ZDNN=0 (default, end-user image) -> :latest AND :$RAG_VERSION
+#   ENABLE_ZDNN=1 (research-only, F16 + zDNN baked in) -> :${RAG_VERSION}_zdnn
+# The zDNN variant must NEVER claim :latest, otherwise an end user pulling the
+# default tag would get the heavier image with the known z17 quality regression.
 source "$REPO_ROOT/version.sh"
-echo "Building image on server (tag: $VERSION, ENABLE_ZDNN=$ENABLE_ZDNN)..."
-ssh $SSH_OPTS "$SSH_HOST" "cd $REMOTE_DIR && source version.sh && docker build --build-arg ENABLE_ZDNN=$ENABLE_ZDNN -f containers/rag-example/Dockerfile.open_llm_s390x -t altastata/rag-open-llm-s390x:latest -t altastata/rag-open-llm-s390x:\$VERSION ."
+if [ "$ENABLE_ZDNN" = "1" ]; then
+  # \${RAG_VERSION}_zdnn -> remote shell expands after `source version.sh`,
+  # then literally appends _zdnn (braces required so _zdnn isn't read as
+  # part of the variable name).
+  TAG_ARGS="-t altastata/rag-open-llm-s390x:\${RAG_VERSION}_zdnn"
+  TAG_REPORT="altastata/rag-open-llm-s390x:${RAG_VERSION}_zdnn"
+else
+  TAG_ARGS="-t altastata/rag-open-llm-s390x:latest -t altastata/rag-open-llm-s390x:\$RAG_VERSION"
+  TAG_REPORT="altastata/rag-open-llm-s390x:$RAG_VERSION (and :latest)"
+fi
+echo "Building image on server (tags: $TAG_REPORT, ENABLE_ZDNN=$ENABLE_ZDNN)..."
+ssh $SSH_OPTS "$SSH_HOST" "cd $REMOTE_DIR && source version.sh && docker build --build-arg ENABLE_ZDNN=$ENABLE_ZDNN -f containers/rag-example/Dockerfile.open_llm_s390x $TAG_ARGS ."
 
-echo "Done. Image altastata/rag-open-llm-s390x:$VERSION (and :latest) is on the server."
+echo "Done. Image $TAG_REPORT is on the server."
 echo "Accounts (if synced) are under $REMOTE_ALTASTATA_ACCOUNTS. Run with:"
-echo "  docker run -p 8000:8000 -e ALTASTATA_ACCOUNT_DIR=$REMOTE_ALTASTATA_ACCOUNTS/amazon.rsa.bob123 -v $REMOTE_ALTASTATA_ACCOUNTS:$REMOTE_ALTASTATA_ACCOUNTS:ro ... altastata/rag-open-llm-s390x:$VERSION"
+echo "  docker run -p 8000:8000 -e ALTASTATA_ACCOUNT_DIR=$REMOTE_ALTASTATA_ACCOUNTS/amazon.rsa.bob123 -v $REMOTE_ALTASTATA_ACCOUNTS:$REMOTE_ALTASTATA_ACCOUNTS:ro ... $TAG_REPORT"

--- a/containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
+++ b/containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
@@ -13,14 +13,15 @@
 #
 # Usage: ./containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
 # Optional: ACCOUNT_NAME=amazon.rsa.hpcs.serge678 ICR_TOKEN=... SSH_HOST=... SSH_KEY=...
-#           REMOTE_GREP11_YAML=... REMOTE_HPCS_BLOB=... REMOTE_PROPERTIES_FILE=... (paths on server)
+#           REMOTE_GREP11_YAML=... REMOTE_HPCS_DIR=... REMOTE_HPCS_BLOB=... REMOTE_PROPERTIES_FILE=... (paths on server)
 #           For 8 GB VM set HF_LLM_MODEL=gpt2 to avoid OOM.
 # Account dir must exist on server at $REMOTE_ALTASTATA_ACCOUNTS/$ACCOUNT_NAME (default /root/.altastata/accounts/...).
 # For HPCS we use three files on the server:
 #   1. grep11client.yaml   — REMOTE_GREP11_YAML (default /etc/ep11client/grep11client.yaml)
-#   2. hpcs-privkey.blob   — REMOTE_HPCS_BLOB (default: inside account dir, .../amazon.rsa.hpcs.serge678/hpcs-privkey.blob)
+#   2. hpcs-privkey.blob   — REMOTE_HPCS_BLOB (default /home/jovyan/hpcs/hpcs-privkey.blob)
 #   3. *.user.properties   — REMOTE_PROPERTIES_FILE (default .../amazon.rsa.hpcs.serge678/altastata-myorgrsa444-serge678.user.properties)
-# Yaml is mounted separately; blob and properties live in the account dir (per-user). Omit hpcs-yaml-path and hpcs-priv-key-blob-path from the properties file.
+# Yaml and blob directory are mounted separately; properties live in the account dir (per-user).
+# Omit hpcs-yaml-path and hpcs-priv-key-blob-path from the properties file.
 
 set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -33,12 +34,17 @@ REMOTE_ALTASTATA_ACCOUNTS="${REMOTE_ALTASTATA_ACCOUNTS:-/root/.altastata/account
 ACCOUNT_NAME="${ACCOUNT_NAME:-amazon.rsa.hpcs.serge678}"
 # All three files on the server (override with env if your paths differ)
 REMOTE_GREP11_YAML="${REMOTE_GREP11_YAML:-/etc/ep11client/grep11client.yaml}"
-REMOTE_HPCS_BLOB="${REMOTE_HPCS_BLOB:-$REMOTE_ALTASTATA_ACCOUNTS/$ACCOUNT_NAME/hpcs-privkey.blob}"
+REMOTE_HPCS_DIR="${REMOTE_HPCS_DIR:-/home/jovyan/hpcs}"
+REMOTE_HPCS_BLOB="${REMOTE_HPCS_BLOB:-$REMOTE_HPCS_DIR/hpcs-privkey.blob}"
 REMOTE_PROPERTIES_FILE="${REMOTE_PROPERTIES_FILE:-$REMOTE_ALTASTATA_ACCOUNTS/$ACCOUNT_NAME/altastata-myorgrsa444-serge678.user.properties}"
 CONTAINER_NAME="rag-s390x-test"
 MAX_WAIT="${MAX_WAIT:-300}"
+# Default LLM provider on s390x: llama.cpp + big-endian GGUF (fast on CPU). Set LLM_PROVIDER=transformers for the slow PyTorch fallback.
+LLM_PROVIDER="${LLM_PROVIDER:-llama-cpp}"
 HF_LLM_MODEL="${HF_LLM_MODEL:-HuggingFaceTB/SmolLM2-360M-Instruct}"
-# Transformers on CPU (s390x) is slow; allow longer for first query
+# GGUF cache on the server, mounted into the container at /models so first-run download persists across container restarts
+REMOTE_MODELS_DIR="${REMOTE_MODELS_DIR:-/root/llama_models}"
+# First query downloads ~700 MB GGUF and loads it; subsequent queries are fast
 QUERY_TIMEOUT="${QUERY_TIMEOUT:-400}"
 RAG_IMAGE="icr.io/altastata/rag-open-llm-s390x:$VERSION"
 
@@ -49,7 +55,10 @@ echo "Three files on server:"
 echo "  yaml:      $REMOTE_GREP11_YAML"
 echo "  blob:      $REMOTE_HPCS_BLOB"
 echo "  properties: $REMOTE_PROPERTIES_FILE"
-echo "HF_LLM_MODEL: $HF_LLM_MODEL"
+echo "LLM_PROVIDER: $LLM_PROVIDER (HF_LLM_MODEL=$HF_LLM_MODEL used only when LLM_PROVIDER=transformers)"
+echo "GGUF cache:   $REMOTE_MODELS_DIR (mounted to /models)"
+echo "Ensuring GGUF cache dir exists on server..."
+ssh $SSH_OPTS "$SSH_HOST" "mkdir -p $REMOTE_MODELS_DIR"
 if [ -n "$ICR_TOKEN" ]; then
   echo "Logging in to icr.io on server (ICR only; no Docker Hub)..."
   echo "$ICR_TOKEN" | ssh $SSH_OPTS "$SSH_HOST" "docker login -u iamapikey --password-stdin icr.io"
@@ -65,17 +74,19 @@ HPCS_MOUNTS=""
 case "$ACCOUNT_NAME" in *hpcs*)
   echo "Checking HPCS files on server..."
   ssh $SSH_OPTS "$SSH_HOST" "for f in '$REMOTE_GREP11_YAML' '$REMOTE_HPCS_BLOB' '$REMOTE_PROPERTIES_FILE'; do if [ ! -f \"\$f\" ]; then echo \"Missing: \$f\"; exit 1; fi; echo \"  OK \$f\"; done"
-  HPCS_ENV="-e ALTASTATA_USE_HPCS=1 -e GREP11_YAML=/etc/ep11client/grep11client.yaml -e HPCS_PRIV_KEY_BLOB_PATH=$REMOTE_ALTASTATA_ACCOUNTS/$ACCOUNT_NAME/hpcs-privkey.blob"
-  HPCS_MOUNTS="-v $REMOTE_GREP11_YAML:/etc/ep11client/grep11client.yaml:ro"
+  HPCS_ENV="-e ALTASTATA_USE_HPCS=1 -e GREP11_YAML=/etc/ep11client/grep11client.yaml -e HPCS_PRIV_KEY_BLOB_PATH=/home/jovyan/hpcs/hpcs-privkey.blob"
+  HPCS_MOUNTS="-v $REMOTE_GREP11_YAML:/etc/ep11client/grep11client.yaml:ro -v $REMOTE_HPCS_DIR:/home/jovyan/hpcs:ro"
   ;;
 esac
 echo "Starting container $CONTAINER_NAME..."
 ssh $SSH_OPTS "$SSH_HOST" "docker run -d --name $CONTAINER_NAME -p 8000:8000 \
   -e ALTASTATA_ACCOUNT_DIR=$REMOTE_ALTASTATA_ACCOUNTS/$ACCOUNT_NAME \
   $HPCS_ENV \
+  -e LLM_PROVIDER=$LLM_PROVIDER \
   -e HF_LLM_MODEL=$HF_LLM_MODEL \
   -e QUERY_TIMEOUT=$QUERY_TIMEOUT \
   -v $REMOTE_ALTASTATA_ACCOUNTS:$REMOTE_ALTASTATA_ACCOUNTS:ro \
+  -v $REMOTE_MODELS_DIR:/models \
   $HPCS_MOUNTS \
   $RAG_IMAGE"
 

--- a/containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
+++ b/containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
@@ -46,7 +46,7 @@ HF_LLM_MODEL="${HF_LLM_MODEL:-HuggingFaceTB/SmolLM2-360M-Instruct}"
 REMOTE_MODELS_DIR="${REMOTE_MODELS_DIR:-/root/llama_models}"
 # First query downloads ~700 MB GGUF and loads it; subsequent queries are fast
 QUERY_TIMEOUT="${QUERY_TIMEOUT:-400}"
-RAG_IMAGE="icr.io/altastata/rag-open-llm-s390x:$VERSION"
+RAG_IMAGE="${RAG_IMAGE:-icr.io/altastata/rag-open-llm-s390x:$RAG_VERSION}"
 
 echo "SSH: $SSH_HOST"
 echo "Pull and run: $RAG_IMAGE"

--- a/containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
+++ b/containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Pull the RAG s390x image from ICR and run it on the server (no local build).
-# Run from repo root on your Mac. Uses same VERSION as Jupyter (version.sh).
+# Run from repo root on your Mac. Default ICR tag is RAG_VERSION from version.sh (not JUPYTER_VERSION).
 #
 # Memory: We recommend 16 GB RAM for the default model (SmolLM2-360M). On 8 GB, set
 #   HF_LLM_MODEL=gpt2 to avoid OOM (weaker answers).

--- a/containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
+++ b/containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
@@ -78,6 +78,17 @@ case "$ACCOUNT_NAME" in *hpcs*)
   HPCS_MOUNTS="-v $REMOTE_GREP11_YAML:/etc/ep11client/grep11client.yaml:ro -v $REMOTE_HPCS_DIR:/home/jovyan/hpcs:ro"
   ;;
 esac
+# Optional passthrough of llama-cpp tuning vars: forwarded to docker run only when the user
+# sets them on the host. By default the in-container entrypoint auto-selects the right GGUF
+# based on /proc/cpuinfo (NNPA -> F16 BE for zDNN; otherwise Q5_K_S). Set
+# LLAMA_CPP_MODEL_FILE to force a specific file (and LLAMA_CPP_MODEL_REPO="" to load
+# from the mounted /models dir without hitting Hugging Face).
+LLAMA_OPTS=""
+[ -n "${LLAMA_CPP_MODEL_REPO+x}" ] && LLAMA_OPTS="$LLAMA_OPTS -e LLAMA_CPP_MODEL_REPO=$LLAMA_CPP_MODEL_REPO"
+[ -n "${LLAMA_CPP_MODEL_FILE:-}" ] && LLAMA_OPTS="$LLAMA_OPTS -e LLAMA_CPP_MODEL_FILE=$LLAMA_CPP_MODEL_FILE"
+[ -n "${LLAMA_CPP_N_CTX:-}" ]      && LLAMA_OPTS="$LLAMA_OPTS -e LLAMA_CPP_N_CTX=$LLAMA_CPP_N_CTX"
+[ -n "${LLAMA_CPP_MAX_TOKENS:-}" ] && LLAMA_OPTS="$LLAMA_OPTS -e LLAMA_CPP_MAX_TOKENS=$LLAMA_CPP_MAX_TOKENS"
+
 echo "Starting container $CONTAINER_NAME..."
 ssh $SSH_OPTS "$SSH_HOST" "docker run -d --name $CONTAINER_NAME -p 8000:8000 \
   -e ALTASTATA_ACCOUNT_DIR=$REMOTE_ALTASTATA_ACCOUNTS/$ACCOUNT_NAME \
@@ -85,6 +96,7 @@ ssh $SSH_OPTS "$SSH_HOST" "docker run -d --name $CONTAINER_NAME -p 8000:8000 \
   -e LLM_PROVIDER=$LLM_PROVIDER \
   -e HF_LLM_MODEL=$HF_LLM_MODEL \
   -e QUERY_TIMEOUT=$QUERY_TIMEOUT \
+  $LLAMA_OPTS \
   -v $REMOTE_ALTASTATA_ACCOUNTS:$REMOTE_ALTASTATA_ACCOUNTS:ro \
   -v $REMOTE_MODELS_DIR:/models \
   $HPCS_MOUNTS \

--- a/containers/rag-example/push-rag-s390x-to-icr-from-server.sh
+++ b/containers/rag-example/push-rag-s390x-to-icr-from-server.sh
@@ -19,9 +19,20 @@ if [ -z "$ICR_TOKEN" ]; then
   exit 1
 fi
 
-echo "Pushing from server $SSH_HOST to icr.io/altastata/rag-open-llm-s390x:$VERSION"
+# Picks tag based on ENABLE_ZDNN (matches build-rag-s390x-on-server.sh):
+#   ENABLE_ZDNN=0 (default) -> push :latest -> :$RAG_VERSION (end-user image)
+#   ENABLE_ZDNN=1           -> push :${RAG_VERSION}_zdnn -> same (research image)
+if [ "${ENABLE_ZDNN:-0}" = "1" ]; then
+  SRC_TAG="altastata/rag-open-llm-s390x:${RAG_VERSION}_zdnn"
+  DST_TAG="icr.io/altastata/rag-open-llm-s390x:${RAG_VERSION}_zdnn"
+else
+  SRC_TAG="altastata/rag-open-llm-s390x:latest"
+  DST_TAG="icr.io/altastata/rag-open-llm-s390x:$RAG_VERSION"
+fi
+
+echo "Pushing from server $SSH_HOST to $DST_TAG (source: $SRC_TAG)"
 echo "Logging in to icr.io on server..."
 echo "$ICR_TOKEN" | ssh $SSH_OPTS "$SSH_HOST" "docker login -u iamapikey --password-stdin icr.io"
 echo "Tag and push..."
-ssh $SSH_OPTS "$SSH_HOST" "docker tag altastata/rag-open-llm-s390x:latest icr.io/altastata/rag-open-llm-s390x:$VERSION && docker push icr.io/altastata/rag-open-llm-s390x:$VERSION"
-echo "Done. Pull with: docker pull icr.io/altastata/rag-open-llm-s390x:$VERSION"
+ssh $SSH_OPTS "$SSH_HOST" "docker tag $SRC_TAG $DST_TAG && docker push $DST_TAG"
+echo "Done. Pull with: docker pull $DST_TAG"

--- a/containers/rag-example/push-rag-s390x-to-icr-from-server.sh
+++ b/containers/rag-example/push-rag-s390x-to-icr-from-server.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Push the RAG s390x image from the LinuxONE server to ICR.
-# Prereq: image built on server (./containers/rag-example/build-rag-s390x-on-server.sh). ICR_TOKEN on your Mac.
+# Prereq: image built on LinuxONE Docker (same host as SSH_HOST) as
+# altastata/rag-open-llm-s390x:latest + :${RAG_VERSION}, or ENABLE_ZDNN build as :${RAG_VERSION}_zdnn
+# (either ./containers/linuxone/build-jupyter-and-rag-on-linuxone.sh on VM, or rsync Mac build script).
 # Run from repo root: ICR_TOKEN=... ./containers/rag-example/push-rag-s390x-to-icr-from-server.sh
 # Research zDNN image on ICR: ENABLE_ZDNN=1 ICR_TOKEN=... ./containers/rag-example/push-rag-s390x-to-icr-from-server.sh
 

--- a/containers/rag-example/push-rag-s390x-to-icr-from-server.sh
+++ b/containers/rag-example/push-rag-s390x-to-icr-from-server.sh
@@ -2,6 +2,7 @@
 # Push the RAG s390x image from the LinuxONE server to ICR.
 # Prereq: image built on server (./containers/rag-example/build-rag-s390x-on-server.sh). ICR_TOKEN on your Mac.
 # Run from repo root: ICR_TOKEN=... ./containers/rag-example/push-rag-s390x-to-icr-from-server.sh
+# Research zDNN image on ICR: ENABLE_ZDNN=1 ICR_TOKEN=... ./containers/rag-example/push-rag-s390x-to-icr-from-server.sh
 
 set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/examples/rag-example/open_llm/README.md
+++ b/examples/rag-example/open_llm/README.md
@@ -428,7 +428,7 @@ Pre-built “model-in-a-container” images (e.g. Red Hat Granite on Docker Hub)
 2. **Push to ICR:** `./containers/rag-example/push-rag-s390x-to-icr-from-server.sh` (requires `ICR_TOKEN`).
 3. **Pull and run:** `./containers/rag-example/pull-and-run-rag-s390x-from-icr.sh` (pulls image on the server, runs container, runs a test query).
 
-**Server setup:** The server needs three files: `grep11client.yaml` (e.g. in `/etc/ep11client/`), and in the account directory (e.g. `/root/.altastata/accounts/amazon.rsa.hpcs.serge678/`) the files `hpcs-privkey.blob` and `*.user.properties` (container-ready: no `hpcs-yaml-path` or `hpcs-priv-key-blob-path` in the properties file). See [containers/jupyter/README-ICR-BUILD-AND-PUSH.md](../../../containers/jupyter/README-ICR-BUILD-AND-PUSH.md) for details.
+**Server setup:** The server needs `grep11client.yaml` (default `/etc/ep11client/grep11client.yaml`), the HPCS key blob at `/home/jovyan/hpcs/hpcs-privkey.blob`, and the account `*.user.properties` file in the account directory (e.g. `/root/.altastata/accounts/amazon.rsa.hpcs.serge678/`). The properties file should be container-ready: no `hpcs-yaml-path` or `hpcs-priv-key-blob-path` entries. See [containers/jupyter/README-ICR-BUILD-AND-PUSH.md](../../../containers/jupyter/README-ICR-BUILD-AND-PUSH.md) for details.
 
 **Build (on s390x host or from Mac via script):**
 ```bash

--- a/examples/rag-example/open_llm/README.md
+++ b/examples/rag-example/open_llm/README.md
@@ -400,7 +400,7 @@ The container logs which file it picked, e.g.
 - `[entrypoint] ENABLE_ZDNN=1 + NNPA hardware + F16 BE GGUF (baked-in /opt/models) -> selecting F16 BE for zDNN acceleration`  *(research builds on z16/z17)*
 - After model load (only with `ENABLE_ZDNN=1`), look for `ZDNN model buffer size = …` (or `register backend zdnn`) in `docker logs <container>` to confirm zDNN actually took the model.
 
-**Deployment for end users (Nicolas-style, including air-gapped):** plain `docker run` — no `scp`, no `/models` mount, no env tweaks needed.
+**Deployment for end users (including air-gapped / confidential envs):** plain `docker run` — no `scp`, no `/models` mount, no env tweaks needed.
 
 ```bash
 docker run -d -p 8000:8000 \

--- a/examples/rag-example/open_llm/README.md
+++ b/examples/rag-example/open_llm/README.md
@@ -364,6 +364,86 @@ Two main ways to run TinyLlama (or similar models) on s390x:
 
 **Building llama.cpp on s390x (optional):** To use a llama.cpp server instead of Transformers, build [llama.cpp on s390x](https://fossies.org/linux/llama.cpp/docs/build-s390x.md) on your host (upstream has s390x CI and big-endian GGUF notes). You can then point `OLLAMA_BASE_URL` at that server or compare latency with the in-container Transformers (TinyLlama) backend.
 
+#### NNPA / zDNN: gated behind `ENABLE_ZDNN` (default OFF)
+
+The [zDNN backend in llama.cpp only accelerates F32 / F16 / BF16 tensors](https://github.com/taronaeo/llama.cpp-s390x/blob/master/docs/backend/zDNN.md) — quantized GGUFs (`Q5_K_S`, `Q4_K_M`, …) never touch the NNPA. To get NNPA acceleration on z16 / z17 you need an **F16 big-endian GGUF**, which is not currently published on Hugging Face for Llama-3.2-1B (we self-convert one — see "Maintainer workflow" below).
+
+⚠️ **Currently disabled by default.** Activating zDNN on z17 was observed to regress query quality vs. the CPU/VXE2 fallback (cause under investigation — possibly an interaction between the zDNN backend and llama.cpp's sampler at our chunk sizes). All zDNN code paths are kept in the Dockerfile and entrypoint so we can re-enable for research without redoing the work, but `ENABLE_ZDNN` defaults to `0`. With the default:
+
+- llama-cpp-python is built with **`-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS`** only (no `-DGGML_ZDNN=ON`); IBM zDNN library build step is skipped (~2 min faster build).
+- F16 BE GGUF is **not** baked into `/opt/models/` (image stays ~4.5 GB instead of ~6.6 GB).
+- Entrypoint short-circuits to **`Q5_K_S`** on every s390x host regardless of `/proc/cpuinfo` NNPA presence.
+
+To re-enable for benchmarking or research:
+
+```bash
+ENABLE_ZDNN=1 ./containers/rag-example/build-rag-s390x-on-server.sh
+```
+
+That single flag flips back on: zDNN library build, `-DGGML_ZDNN=ON` in cmake, F16 BE GGUF staging + bake-in, and the entrypoint's NNPA-detection logic that prefers F16 over Q5_K_S when both are available.
+
+#### NNPA auto-selection of GGUF (only when `ENABLE_ZDNN=1`)
+
+When the image is built with `ENABLE_ZDNN=1`, the entrypoint picks the right model based on hardware:
+
+| Hardware | NNPA in `/proc/cpuinfo`? | F16 BE file reachable? (`/models` then `/opt/models`) | Selected GGUF |
+|---|---|---|---|
+| z15 | no | doesn't matter | `Q5_K_S` (CPU only — quantized is faster than F16 here) |
+| z16 / z17 | yes | baked-in `/opt/models/...f16.gguf` (always present with `ENABLE_ZDNN=1`) | `F16 BE` from `/opt/models/` (zDNN / NNPA) |
+| any | — | host-supplied via `-v <dir>:/models` (overrides baked) | `F16 BE` from `/models/` |
+
+User overrides win: any explicit `LLAMA_CPP_MODEL_FILE` / `LLAMA_CPP_MODEL_REPO` from `docker run -e ...` skips auto-detect entirely.
+
+The container logs which file it picked, e.g.
+
+- `[entrypoint] ENABLE_ZDNN=0 (image built without NNPA acceleration); using llama-3.2-1b-instruct-be.Q5_K_S.gguf on CPU/VXE2 regardless of /proc/cpuinfo.`  *(default builds)*
+- `[entrypoint] ENABLE_ZDNN=1 + NNPA hardware + F16 BE GGUF (baked-in /opt/models) -> selecting F16 BE for zDNN acceleration`  *(research builds on z16/z17)*
+- After model load (only with `ENABLE_ZDNN=1`), look for `ZDNN model buffer size = …` (or `register backend zdnn`) in `docker logs <container>` to confirm zDNN actually took the model.
+
+**Deployment for end users (Nicolas-style, including air-gapped):** plain `docker run` — no `scp`, no `/models` mount, no env tweaks needed.
+
+```bash
+docker run -d -p 8000:8000 \
+  -e ALTASTATA_ACCOUNT_DIR=/path/to/altastata-account \
+  -v /path/to/altastata-accounts:/path/to/altastata-accounts:ro \
+  icr.io/altastata/rag-open-llm-s390x:<VERSION>
+```
+
+**Maintainer workflow (us, when shipping a new image):**
+
+1. **One-time** on a Mac (~2 min, ~5 GB free disk) — only needed if you ever want to flip `ENABLE_ZDNN=1`. Produces the F16 BE GGUF the build script will stage:
+
+   ```bash
+   ./containers/rag-example/build-llama32-1b-f16-be-gguf.sh
+   # Internally: download unsloth/Llama-3.2-1B-Instruct-GGUF/Llama-3.2-1B-Instruct-F16.gguf,
+   # byte-swap to big-endian via `python -m gguf.scripts.gguf_convert_endian`, verify.
+   # Result: ~/llama_models/llama-3.2-1b-instruct-be.f16.gguf
+
+   scp ~/llama_models/llama-3.2-1b-instruct-be.f16.gguf root@<linuxone>:/root/llama_models/
+   ```
+
+2. **Every build** — by default (`ENABLE_ZDNN=0`) the build script stages a tiny placeholder (the Dockerfile deletes it from `/opt/models`) and skips the zDNN library / cmake flag, producing a ~4.5 GB CPU/VXE2 image:
+
+   ```bash
+   ./containers/rag-example/build-rag-s390x-on-server.sh
+   ICR_TOKEN=… ./containers/rag-example/push-rag-s390x-to-icr-from-server.sh
+   ```
+
+   For research builds with the F16 + zDNN path active (~6.6 GB image), set the flag:
+
+   ```bash
+   ENABLE_ZDNN=1 ./containers/rag-example/build-rag-s390x-on-server.sh
+   ```
+
+**Smoke-test F16 on z15** (only meaningful for `ENABLE_ZDNN=1` builds — the file loads on plain CPU, slower than Q5_K_S, but proves the bundled file isn't corrupt before handing the image to z16/z17 users):
+
+```bash
+LLAMA_CPP_MODEL_REPO= \
+  LLAMA_CPP_MODEL_FILE=llama-3.2-1b-instruct-be.f16.gguf \
+  LLAMA_CPP_MODEL_DIR=/opt/models \
+  ./containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
+```
+
 ### Simplest run on IBM Z (s390x) – no Docker build
 
 Run the RAG stack on 390 **without building any Docker images**: use Python on the s390x host and a **remote** LLM so you don’t need Ollama on 390.

--- a/examples/rag-example/open_llm/config.py
+++ b/examples/rag-example/open_llm/config.py
@@ -24,7 +24,8 @@ LOCAL_INDEX_PATH = os.getenv("LOCAL_INDEX_PATH", os.path.join(os.path.dirname(__
 # Embeddings
 EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
 
-# LLM: "mlx" (fastest on M1/Mac), "ollama" (fast on Mac with Metal), "transformers" (Mac + IBM 390, slow on CPU), or "watsonx" (IBM Cloud / Granite API).
+# LLM: "mlx" (fastest on M1/Mac), "ollama" (fast on Mac with Metal), "llama-cpp" (fast on s390x via llama.cpp + GGUF),
+#      "transformers" (Mac + IBM 390, slow on CPU), or "watsonx" (IBM Cloud / Granite API).
 # If unset, use ollama when Ollama is reachable, else transformers.
 def _default_llm_provider():
     env_val = os.getenv("LLM_PROVIDER", "").strip().lower()
@@ -51,6 +52,22 @@ OLLAMA_NUM_PREDICT = int(os.getenv("OLLAMA_NUM_PREDICT", "128"))
 # MLX (when LLM_PROVIDER=mlx). Fastest on Apple Silicon; Mac-only. Small 4-bit models: Llama-3.2-1B-Instruct-4bit, etc.
 MLX_MODEL = os.getenv("MLX_MODEL", "mlx-community/Llama-3.2-1B-Instruct-4bit")
 MLX_MAX_TOKENS = int(os.getenv("MLX_MAX_TOKENS", "128"))
+
+# llama-cpp-python (when LLM_PROVIDER=llama-cpp). Local CPU inference via llama.cpp + GGUF quantization.
+# Same engine that powers Ollama; runs natively on s390x with OpenBLAS (must use big-endian GGUFs).
+# Verified s390x models: https://huggingface.co/collections/taronaeo/s390x-runnable-models
+LLAMA_CPP_MODEL_REPO = os.getenv("LLAMA_CPP_MODEL_REPO", "taronaeo/Llama-3.2-1B-Instruct-BE-GGUF")
+LLAMA_CPP_MODEL_FILE = os.getenv("LLAMA_CPP_MODEL_FILE", "llama-3.2-1b-instruct-be.Q5_K_S.gguf")
+# Cache dir for downloaded GGUFs (mount as a Docker volume to persist across runs)
+LLAMA_CPP_MODEL_DIR = os.getenv("LLAMA_CPP_MODEL_DIR", "/models")
+LLAMA_CPP_N_CTX = int(os.getenv("LLAMA_CPP_N_CTX", "2048"))
+# 0 means let llama.cpp pick based on CPU count
+LLAMA_CPP_N_THREADS = int(os.getenv("LLAMA_CPP_N_THREADS", "0"))
+LLAMA_CPP_MAX_TOKENS = int(os.getenv("LLAMA_CPP_MAX_TOKENS", "256"))
+# Note: we intentionally do NOT expose a separate "system" prompt for llama-cpp.
+# Sending a system role message to the big-endian Llama-3.2 GGUF on s390x segfaults
+# llama.cpp's chat-template handler. Any guidance must live in the user prompt itself
+# (see the prompt construction in query_rag.py).
 
 # Hugging Face Transformers (when LLM_PROVIDER=transformers). Same on Mac, Docker, and IBM 390.
 # SmolLM2-360M is faster than TinyLlama on CPU; for much faster responses on Mac use LLM_PROVIDER=ollama with Ollama on the host.

--- a/examples/rag-example/open_llm/config.py
+++ b/examples/rag-example/open_llm/config.py
@@ -47,7 +47,10 @@ LLM_PROVIDER = _default_llm_provider()
 # Ollama (when LLM_PROVIDER=ollama). Use small models for fast response: smollm2:360m, qwen2.5:0.5b, llama3.2:1b
 OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
 OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "smollm2:360m")
-OLLAMA_NUM_PREDICT = int(os.getenv("OLLAMA_NUM_PREDICT", "128"))
+# 512 (was 128): 128 cuts multi-item answers off mid-list (e.g. "The password
+# requirements are: " then truncated). 512 still finishes in seconds on
+# llama3.2:1b via host Ollama with Metal; safe upper bound for short RAG answers.
+OLLAMA_NUM_PREDICT = int(os.getenv("OLLAMA_NUM_PREDICT", "512"))
 
 # MLX (when LLM_PROVIDER=mlx). Fastest on Apple Silicon; Mac-only. Small 4-bit models: Llama-3.2-1B-Instruct-4bit, etc.
 MLX_MODEL = os.getenv("MLX_MODEL", "mlx-community/Llama-3.2-1B-Instruct-4bit")

--- a/examples/rag-example/open_llm/docker-entrypoint.sh
+++ b/examples/rag-example/open_llm/docker-entrypoint.sh
@@ -55,5 +55,61 @@ if [ -n "$ALTASTATA_ACCOUNT_DIR" ] && [ -d "$ALTASTATA_ACCOUNT_DIR" ]; then
   python -m indexer &
 fi
 
+# Auto-select GGUF for llama-cpp based on s390x hardware capability:
+#   * z16 / z17 (Telum I/II) advertise the 'nnpa' facility in /proc/cpuinfo and
+#     can run llama.cpp's zDNN backend, which only accelerates F32/F16/BF16
+#     tensors. We prefer a self-converted F16 BE GGUF so zDNN actually
+#     accelerates work at runtime.
+#   * z15 and earlier (no NNPA) — or any host where no F16 file is reachable —
+#     fall back to the smaller Q5_K_S quantization, which runs faster on plain
+#     CPU/VXE2 than F16 would.
+# Two F16 sources are checked, in priority order:
+#   1. /models/<F16_FILE>  — user-supplied via -v <host_dir>:/models
+#   2. /opt/models/<F16_FILE> — baked into the image at build time (default;
+#      see Dockerfile.open_llm_s390x), so a plain `docker run` works in
+#      confidential / air-gapped envs with no host-side setup.
+# User overrides win: any explicit LLAMA_CPP_MODEL_FILE or LLAMA_CPP_MODEL_REPO
+# from `docker run -e ...` is left untouched.
+#
+# When the image is built with ENABLE_ZDNN=0 (current default — see
+# Dockerfile.open_llm_s390x for why), llama-cpp-python has no zDNN backend, the
+# F16 GGUF is not baked in, and even if a user mounts one over /models it would
+# run slower than Q5_K_S on plain CPU. So we short-circuit: always pick Q5_K_S.
+if [ "${LLM_PROVIDER:-llama-cpp}" = "llama-cpp" ] && [ -z "${LLAMA_CPP_MODEL_FILE:-}" ]; then
+  _F16_FILE="llama-3.2-1b-instruct-be.f16.gguf"
+  _Q5_FILE="llama-3.2-1b-instruct-be.Q5_K_S.gguf"
+  _USER_MODELS_DIR="${LLAMA_CPP_MODEL_DIR:-/models}"
+  _BAKED_MODELS_DIR="/opt/models"
+
+  if [ "${ENABLE_ZDNN:-0}" != "1" ]; then
+    export LLAMA_CPP_MODEL_FILE="$_Q5_FILE"
+    echo "[entrypoint] ENABLE_ZDNN=0 (image built without NNPA acceleration); using $_Q5_FILE on CPU/VXE2 regardless of /proc/cpuinfo."
+  else
+    _F16_PATH=""
+    if [ -f "$_USER_MODELS_DIR/$_F16_FILE" ]; then
+      _F16_PATH="$_USER_MODELS_DIR/$_F16_FILE"
+      _F16_SRC="user-supplied $_USER_MODELS_DIR"
+    elif [ -f "$_BAKED_MODELS_DIR/$_F16_FILE" ]; then
+      _F16_PATH="$_BAKED_MODELS_DIR/$_F16_FILE"
+      _F16_SRC="baked-in $_BAKED_MODELS_DIR"
+    fi
+
+    if grep -qE '^features[[:space:]]*:.*\bnnpa\b' /proc/cpuinfo 2>/dev/null \
+       && [ -n "$_F16_PATH" ]; then
+      export LLAMA_CPP_MODEL_FILE="$_F16_FILE"
+      export LLAMA_CPP_MODEL_REPO=""
+      export LLAMA_CPP_MODEL_DIR="$(dirname "$_F16_PATH")"
+      echo "[entrypoint] ENABLE_ZDNN=1 + NNPA hardware + F16 BE GGUF ($_F16_SRC) -> selecting F16 BE for zDNN acceleration"
+    else
+      export LLAMA_CPP_MODEL_FILE="$_Q5_FILE"
+      if grep -qE '^features[[:space:]]*:.*\bnnpa\b' /proc/cpuinfo 2>/dev/null; then
+        echo "[entrypoint] ENABLE_ZDNN=1 + NNPA hardware detected but no $_F16_FILE in $_USER_MODELS_DIR or $_BAKED_MODELS_DIR; using $_Q5_FILE (no zDNN acceleration)."
+      else
+        echo "[entrypoint] ENABLE_ZDNN=1 but no NNPA in /proc/cpuinfo; using $_Q5_FILE (CPU path)."
+      fi
+    fi
+  fi
+fi
+
 echo "[entrypoint] Starting web server on port ${WEB_PORT:-8000}..."
 exec "$@"

--- a/examples/rag-example/open_llm/query_rag.py
+++ b/examples/rag-example/open_llm/query_rag.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-Open-source RAG query: vector search + AltaStata (chunk content) + LLM (MLX, Ollama, or Hugging Face Transformers).
+Open-source RAG query: vector search + AltaStata (chunk content) + LLM (MLX, Ollama, llama.cpp, Transformers, or watsonx).
 
-Use LLM_PROVIDER=mlx for fastest on M1/Mac; LLM_PROVIDER=transformers for same stack on Mac and IBM 390.
+Use LLM_PROVIDER=mlx for fastest on M1/Mac, LLM_PROVIDER=llama-cpp for fastest on s390x (CPU + GGUF),
+LLM_PROVIDER=transformers for the slowest-but-most-portable PyTorch path.
 Returns answer and source chunks for citations.
 """
 
@@ -26,6 +27,12 @@ from config import (
     OLLAMA_NUM_PREDICT,
     MLX_MODEL,
     MLX_MAX_TOKENS,
+    LLAMA_CPP_MODEL_REPO,
+    LLAMA_CPP_MODEL_FILE,
+    LLAMA_CPP_MODEL_DIR,
+    LLAMA_CPP_N_CTX,
+    LLAMA_CPP_N_THREADS,
+    LLAMA_CPP_MAX_TOKENS,
     HF_LLM_MODEL,
     HF_LLM_MAX_NEW_TOKENS,
     HF_LLM_FALLBACK_MODEL,
@@ -165,6 +172,54 @@ def _get_llm():
                         model_to_use = HF_LLM_FALLBACK_MODEL
                     else:
                         raise
+        elif LLM_PROVIDER in ("llama-cpp", "llama_cpp", "llamacpp"):
+            try:
+                import llama_cpp
+                from huggingface_hub import hf_hub_download
+            except ImportError as e:
+                raise ImportError(
+                    "LLM_PROVIDER=llama-cpp requires llama-cpp-python and huggingface_hub. "
+                    "On s390x install with: "
+                    "CMAKE_ARGS=\"-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS\" "
+                    "pip install llama-cpp-python huggingface_hub"
+                ) from e
+            print(
+                f"[llama-cpp] Resolving GGUF {LLAMA_CPP_MODEL_REPO}/{LLAMA_CPP_MODEL_FILE} "
+                f"(cache_dir={LLAMA_CPP_MODEL_DIR})..."
+            )
+            os.makedirs(LLAMA_CPP_MODEL_DIR, exist_ok=True)
+            gguf_path = hf_hub_download(
+                repo_id=LLAMA_CPP_MODEL_REPO,
+                filename=LLAMA_CPP_MODEL_FILE,
+                cache_dir=LLAMA_CPP_MODEL_DIR,
+            )
+            print(f"[llama-cpp] Loading {gguf_path} (n_ctx={LLAMA_CPP_N_CTX})...")
+            _llm_obj = llama_cpp.Llama(
+                model_path=gguf_path,
+                n_ctx=LLAMA_CPP_N_CTX,
+                n_threads=(LLAMA_CPP_N_THREADS or None),
+                verbose=False,
+            )
+
+            class _LlamaCppChat:
+                def __init__(self, llm, max_tokens):
+                    self._llm = llm
+                    self._max_tokens = max_tokens
+
+                def invoke(self, prompt):
+                    # Note: we deliberately send only a `user` message (no `system` role).
+                    # The big-endian Llama-3.2 GGUF chat template segfaults on s390x when
+                    # given a separate system message, so any guidance must live inside
+                    # the user prompt itself (see _query_rag in this file).
+                    out = self._llm.create_chat_completion(
+                        messages=[{"role": "user", "content": prompt}],
+                        max_tokens=self._max_tokens,
+                        temperature=0.1,
+                    )
+                    content = out["choices"][0]["message"]["content"]
+                    return type("R", (), {"content": content})()
+
+            _cached_llm = _LlamaCppChat(_llm_obj, LLAMA_CPP_MAX_TOKENS)
         elif LLM_PROVIDER == "watsonx":
             if not WATSONX_APIKEY or not WATSONX_PROJECT_ID:
                 raise ValueError(
@@ -286,7 +341,7 @@ def query_rag(
             sources.append(src)
 
     context = "\n\n".join([f"[Excerpt {i+1}]:\n{t}" for i, t in enumerate(chunk_texts)])
-    prompt = f"""Answer in 2-4 short sentences. Use only the context below. If the context doesn't have the answer, say "Not in the documents."
+    prompt = f"""Answer the question in 2-4 short sentences using only the context below.
 
 Context:
 {context}

--- a/examples/rag-example/open_llm/query_rag.py
+++ b/examples/rag-example/open_llm/query_rag.py
@@ -175,24 +175,46 @@ def _get_llm():
         elif LLM_PROVIDER in ("llama-cpp", "llama_cpp", "llamacpp"):
             try:
                 import llama_cpp
-                from huggingface_hub import hf_hub_download
             except ImportError as e:
                 raise ImportError(
-                    "LLM_PROVIDER=llama-cpp requires llama-cpp-python and huggingface_hub. "
+                    "LLM_PROVIDER=llama-cpp requires llama-cpp-python. "
                     "On s390x install with: "
                     "CMAKE_ARGS=\"-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS\" "
                     "pip install llama-cpp-python huggingface_hub"
                 ) from e
-            print(
-                f"[llama-cpp] Resolving GGUF {LLAMA_CPP_MODEL_REPO}/{LLAMA_CPP_MODEL_FILE} "
-                f"(cache_dir={LLAMA_CPP_MODEL_DIR})..."
-            )
-            os.makedirs(LLAMA_CPP_MODEL_DIR, exist_ok=True)
-            gguf_path = hf_hub_download(
-                repo_id=LLAMA_CPP_MODEL_REPO,
-                filename=LLAMA_CPP_MODEL_FILE,
-                cache_dir=LLAMA_CPP_MODEL_DIR,
-            )
+            # Two ways to point at a GGUF:
+            #   1. LLAMA_CPP_MODEL_REPO + LLAMA_CPP_MODEL_FILE -> hf_hub_download into LLAMA_CPP_MODEL_DIR.
+            #   2. LLAMA_CPP_MODEL_REPO empty -> load LLAMA_CPP_MODEL_DIR/LLAMA_CPP_MODEL_FILE directly.
+            #      Used by the s390x entrypoint when it auto-selects a self-converted F16 BE GGUF
+            #      (not published on Hugging Face) for the zDNN/NNPA path on z16/z17.
+            if LLAMA_CPP_MODEL_REPO and LLAMA_CPP_MODEL_REPO.strip():
+                try:
+                    from huggingface_hub import hf_hub_download
+                except ImportError as e:
+                    raise ImportError(
+                        "LLAMA_CPP_MODEL_REPO is set but huggingface_hub is not installed. "
+                        "Install: pip install huggingface_hub  (or unset LLAMA_CPP_MODEL_REPO and "
+                        "mount the GGUF at LLAMA_CPP_MODEL_DIR/LLAMA_CPP_MODEL_FILE)."
+                    ) from e
+                print(
+                    f"[llama-cpp] Resolving GGUF {LLAMA_CPP_MODEL_REPO}/{LLAMA_CPP_MODEL_FILE} "
+                    f"(cache_dir={LLAMA_CPP_MODEL_DIR})..."
+                )
+                os.makedirs(LLAMA_CPP_MODEL_DIR, exist_ok=True)
+                gguf_path = hf_hub_download(
+                    repo_id=LLAMA_CPP_MODEL_REPO,
+                    filename=LLAMA_CPP_MODEL_FILE,
+                    cache_dir=LLAMA_CPP_MODEL_DIR,
+                )
+            else:
+                gguf_path = os.path.join(LLAMA_CPP_MODEL_DIR, LLAMA_CPP_MODEL_FILE)
+                if not os.path.isfile(gguf_path):
+                    raise FileNotFoundError(
+                        f"LLAMA_CPP_MODEL_REPO is empty so the GGUF must already exist at {gguf_path}, "
+                        f"but no such file was found. Either set LLAMA_CPP_MODEL_REPO=<hf repo> or "
+                        f"mount a directory containing {LLAMA_CPP_MODEL_FILE!r} at {LLAMA_CPP_MODEL_DIR}."
+                    )
+                print(f"[llama-cpp] Using local GGUF {gguf_path} (LLAMA_CPP_MODEL_REPO is empty)...")
             print(f"[llama-cpp] Loading {gguf_path} (n_ctx={LLAMA_CPP_N_CTX})...")
             _llm_obj = llama_cpp.Llama(
                 model_path=gguf_path,
@@ -341,7 +363,13 @@ def query_rag(
             sources.append(src)
 
     context = "\n\n".join([f"[Excerpt {i+1}]:\n{t}" for i, t in enumerate(chunk_texts)])
-    prompt = f"""Answer the question in 2-4 short sentences using only the context below.
+    # Earlier prompt said "Answer in 2-4 short sentences" which fought list-style
+    # questions ("what are the password requirements?"): small models resolved the
+    # conflict by emitting just the lead-in ("The password requirements are as
+    # follows:") and stopping. Allowing bullets when the answer is naturally a
+    # list fixes the intermittent truncation; cap length so prose answers stay
+    # short.
+    prompt = f"""Answer the question using only the context below. Be concise (under 6 sentences). If the answer is naturally a list of items, return it as a bulleted list.
 
 Context:
 {context}

--- a/examples/rag-example/open_llm/requirements.txt
+++ b/examples/rag-example/open_llm/requirements.txt
@@ -17,6 +17,11 @@ python-dotenv
 transformers
 accelerate
 
-# Optional: Ollama → pip install langchain-ollama
+# ---- LLM backend (Ollama: LLM_PROVIDER=ollama, e.g. Mac with host Ollama) ----
+# Bundled even when LLM_PROVIDER=transformers is the default — pulling it in adds
+# ~25 kB and avoids the `docker exec ... pip install langchain-ollama` workaround
+# every time someone switches to Ollama on Mac.
+langchain-ollama
+
 # Optional: watsonx → pip install langchain-ibm
 # Optional: MLX (Mac only) → pip install mlx mlx-lm

--- a/examples/rag-example/open_llm/web_app.py
+++ b/examples/rag-example/open_llm/web_app.py
@@ -99,7 +99,7 @@ class QueryRequest(BaseModel):
 
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse(request, "index.html")
 
 
 @app.get("/debug")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='altastata',
-    version='0.1.27',
+    version='0.1.28',
     author='Serge Vilvovsky',
     author_email='serge.vilvovsky@altastata.com',
     description='A Python package for Altastata data processing and machine learning integration',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='altastata',
-    version='0.1.26',
+    version='0.1.27',
     author='Serge Vilvovsky',
     author_email='serge.vilvovsky@altastata.com',
     description='A Python package for Altastata data processing and machine learning integration',

--- a/update-version.sh
+++ b/update-version.sh
@@ -8,12 +8,14 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/version.sh"
 
-# Validate version is set
-if [ -z "$VERSION" ]; then
-    echo "Error: VERSION is not set in version.sh"
-    echo "Please ensure version.sh contains: VERSION=\"your_version\""
+if [ -z "$JUPYTER_VERSION" ]; then
+    echo "Error: JUPYTER_VERSION not set in version.sh"
     exit 1
 fi
+# This script writes .env (docker-compose) and the GKE deployment manifest, both
+# of which deploy the Jupyter image (jupyter-datascience-amd64). RAG has no
+# docker-compose / k8s deployment yet, so we only forward JUPYTER_VERSION here.
+VERSION="$JUPYTER_VERSION"
 
 # Detect architecture for docker-compose
 ARCH=$(uname -m)

--- a/version.sh
+++ b/version.sh
@@ -1,13 +1,27 @@
 #!/bin/bash
 # Single source of truth for versions used by build / push scripts.
 #
-#  VERSION                = Docker image tag (jupyter-datascience-*, rag-open-llm-*).
-#                           Edit this file to bump.
+#  JUPYTER_VERSION        = Docker image tag for jupyter-datascience-{arm64,amd64,s390x}.
+#                           Bump only when the Jupyter image gains a real feature
+#                           change (kernel, base image, layout). A new altastata
+#                           wheel from PyPI does NOT require bumping this — pip
+#                           just installs the newer wheel into the same image.
+#  RAG_VERSION            = Docker image tag for rag-open-llm-s390x (and the
+#                           :${RAG_VERSION}_zdnn research variant). Bumped on
+#                           every meaningful RAG image change (entrypoint logic,
+#                           llama.cpp flags, new GGUF default, etc.).
 #  ALTASTATA_PYPI_VERSION = altastata Python package version published to PyPI.
 #                           Extracted dynamically from setup.py so we never need
 #                           to bump it in two places.
+#
+# Why two image versions: Jupyter and RAG release on different cadences. Jupyter
+# has been stable since 2026c (just absorbing altastata wheel bumps); RAG went
+# through several iterations (2026d..2026g) for llama.cpp + GGUF + zDNN gating
+# work. Separating the tags keeps each image's history truthful and avoids
+# end-user confusion ("did Jupyter change between 2026e and 2026g?" — no).
 
-VERSION="2026g_latest"
+JUPYTER_VERSION="2026c_latest"
+RAG_VERSION="2026g_latest"
 
 # Resolve repo root from this script's location so callers can `source version.sh`
 # from any cwd. Falls back to the current dir if BASH_SOURCE isn't available.

--- a/version.sh
+++ b/version.sh
@@ -7,7 +7,7 @@
 #                           Extracted dynamically from setup.py so we never need
 #                           to bump it in two places.
 
-VERSION="2026f_latest"
+VERSION="2026g_latest"
 
 # Resolve repo root from this script's location so callers can `source version.sh`
 # from any cwd. Falls back to the current dir if BASH_SOURCE isn't available.

--- a/version.sh
+++ b/version.sh
@@ -1,6 +1,24 @@
 #!/bin/bash
-# Docker image version configuration
-# Update this file to change the version across all scripts
+# Single source of truth for versions used by build / push scripts.
+#
+#  VERSION                = Docker image tag (jupyter-datascience-*, rag-open-llm-*).
+#                           Edit this file to bump.
+#  ALTASTATA_PYPI_VERSION = altastata Python package version published to PyPI.
+#                           Extracted dynamically from setup.py so we never need
+#                           to bump it in two places.
 
-VERSION="2026c_latest"
+VERSION="2026f_latest"
 
+# Resolve repo root from this script's location so callers can `source version.sh`
+# from any cwd. Falls back to the current dir if BASH_SOURCE isn't available.
+_VERSION_SH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+ALTASTATA_PYPI_VERSION="$(
+  awk -F"['\"]" '/^[[:space:]]*version[[:space:]]*=/ {print $2; exit}' \
+    "${_VERSION_SH_DIR}/setup.py"
+)"
+unset _VERSION_SH_DIR
+
+if [ -z "$ALTASTATA_PYPI_VERSION" ]; then
+  echo "version.sh: ERROR: failed to extract version from setup.py" >&2
+  return 1 2>/dev/null || exit 1
+fi


### PR DESCRIPTION
## Summary

Merges `openshift` into `main`: s390x RAG + Jupyter workflows, clearer Mac vs VM orchestration, image versioning split, and package version hygiene.

### Package / versioning
- Split image tags in `version.sh`: `JUPYTER_VERSION` (`2026c_latest`) vs `RAG_VERSION` (`2026g_latest` + optional `*_zdnn`).
- `altastata.__version__` derives from package metadata (`setup.py`); PyPI bumps to **0.1.28**.

### RAG (s390x)
- Llama.cpp path, GGUF wiring, prompt fixes; optional **ENABLE_ZDNN=1** F16 BE research variant vs CPU default (**ENABLE_ZDNN=0**).
- Build/push scripts aligned with tagging; SSH orchestration hardened (parse fix, detached builds, workstation vs s390x guards).

### Jupyter / containers
- s390x on-server build + push-to-ICR mirrored after RAG pattern.
- `push-to-ghcr.sh`: arm64-first; optional amd64 via `PUSH_JUPYTER_AMD64_TO_GHCR=1`; `SKIP_JUPYTER_ARM64_BUILD=1` for push-only.
- LinuxONE: `build-jupyter-and-rag-on-linuxone.sh` with `SKIP_JUPYTER=1`; **run-jupyter-and-rag-on-server-for-browser.sh** for long-lived smoke in browser.
- `.gitignore`: rag local props + `rag-zdnn-build.log`.

### Docs / tooling
- ICR README and script comments aligned with separate Jupyter/RAG versions.
- Cursor rules + `CLAUDE.md`: assistant git workflow and LinuxONE deployment notes.

**Note:** Prefer reviewing by commit series above; squash-merge vs merge commit is repo preference.

Made with [Cursor](https://cursor.com)