### PR TITLE
docs: RAG_VERSION in s390x/LinuxONE readme snippets

### DIFF
--- a/containers/jupyter/IBM-LINUXONE-S390X-SETUP.md
+++ b/containers/jupyter/IBM-LINUXONE-S390X-SETUP.md
@@ -326,7 +326,7 @@ The **Open LLM RAG** app (simple vector store + Transformers + AltaStata) can be
 ```bash
 ./containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
 ```
-- SSHs to the server, **stops/removes** any existing `rag-s390x-test` container **before** pulling, pulls `icr.io/altastata/rag-open-llm-s390x:$VERSION`, runs the container, runs a test query, then **leaves the container running** (no stop/rm at the end).
+- SSHs to the server, **stops/removes** any existing `rag-s390x-test` container **before** pulling, pulls `icr.io/altastata/rag-open-llm-s390x:${RAG_VERSION}` (same as **`RAG_VERSION`** in repo **`version.sh`**), runs the container, runs a test query, then **leaves the container running** (no stop/rm at the end).
 - Set **`ICR_TOKEN`** on your Mac so the script can log in to icr.io on the server before pull.
 - **Account:** Default is **HPCS** (`amazon.rsa.hpcs.serge678`; no password). For **bob123** (password-based):
   ```bash
@@ -334,10 +334,10 @@ The **Open LLM RAG** app (simple vector store + Transformers + AltaStata) can be
   ```
 - Optional: `SSH_HOST`, `SSH_KEY`, `HF_LLM_MODEL=gpt2` (8 GB VMs). See [README-ICR-BUILD-AND-PUSH.md](README-ICR-BUILD-AND-PUSH.md) for full pull-and-run options.
 
-Or manually on the server:
+Or manually on the server (from repo root; RAG tag is **`RAG_VERSION`**, not Jupyter’s **`JUPYTER_VERSION`**):
 ```bash
-source version.sh 2>/dev/null || VERSION="2026c_latest"
-docker pull icr.io/altastata/rag-open-llm-s390x:${VERSION}
+source ./version.sh
+docker pull icr.io/altastata/rag-open-llm-s390x:${RAG_VERSION}
 # Then run with your account dir; see "Run the container" below.
 ```
 

--- a/examples/rag-example/open_llm/README.md
+++ b/examples/rag-example/open_llm/README.md
@@ -515,15 +515,16 @@ Pre-built “model-in-a-container” images (e.g. Red Hat Granite on Docker Hub)
 # From Mac – sync repo and build on the LinuxONE server (recommended)
 ./containers/rag-example/build-rag-s390x-on-server.sh
 
-# Or on the s390x server directly
-source ../../../version.sh 2>/dev/null || true
+# Or on the s390x server directly (from repo root; image tag = RAG_VERSION in version.sh)
+source ./version.sh
 docker build -f containers/rag-example/Dockerfile.open_llm_s390x --platform linux/s390x \
-  -t altastata/rag-open-llm-s390x:latest -t altastata/rag-open-llm-s390x:${VERSION:-2026b_latest} .
+  -t altastata/rag-open-llm-s390x:latest -t altastata/rag-open-llm-s390x:${RAG_VERSION} .
 ```
 
-**Run (after build or pull from ICR):** Use the same version tag as the Jupyter image (from `version.sh`).
+**Run (after build or pull from ICR):** Use **`RAG_VERSION`** from **`version.sh`** for the image tag.
 ```bash
-source ../../../version.sh 2>/dev/null || true
+# From repository root
+source ./version.sh
 # Replace with your AltaStata account dir (must contain the account subdir, e.g. amazon.rsa.bob123)
 export ALTASTATA_ACCOUNT_DIR="$HOME/.altastata/accounts/amazon.rsa.bob123"
 
@@ -532,15 +533,16 @@ docker run -d -p 8000:8000 --name rag \
   -e ALTASTATA_ACCOUNT_DIR=$ALTASTATA_ACCOUNT_DIR \
   -e HF_LLM_MODEL=TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
   -v "$(dirname $ALTASTATA_ACCOUNT_DIR)":/root/.altastata/accounts:ro \
-  altastata/rag-open-llm-s390x:${VERSION:-2026b_latest}
+  altastata/rag-open-llm-s390x:${RAG_VERSION}
 # Open http://<host>:8000/
 ```
 
-**Pull from IBM Container Registry (ICR):** See [containers/jupyter/README-ICR-BUILD-AND-PUSH.md](../../../containers/jupyter/README-ICR-BUILD-AND-PUSH.md) for push; to run from a pre-pushed image (tag matches Jupyter image, e.g. 2026b_latest from `version.sh`):
+**Pull from IBM Container Registry (ICR):** See [containers/jupyter/README-ICR-BUILD-AND-PUSH.md](../../../containers/jupyter/README-ICR-BUILD-AND-PUSH.md) for push; to run from a pre-pushed image (tag **`RAG_VERSION`** in `version.sh`):
 ```bash
-source ../../../version.sh 2>/dev/null || true
-docker pull icr.io/altastata/rag-open-llm-s390x:${VERSION:-2026b_latest}
-# Then run as above, using image icr.io/altastata/rag-open-llm-s390x:${VERSION}
+# From repository root
+source ./version.sh
+docker pull icr.io/altastata/rag-open-llm-s390x:${RAG_VERSION}
+# Then run as above, using image icr.io/altastata/rag-open-llm-s390x:${RAG_VERSION}
 ```
 
 **Pull and run from your Mac (script):** From repo root run `./containers/rag-example/pull-and-run-rag-s390x-from-icr.sh`. It SSHs to the server, stops/removes any existing RAG container, pulls the image, runs the container, runs a test query, and leaves the container running. Set `ICR_TOKEN` on your Mac. **Accounts:** Default is **HPCS** (`amazon.rsa.hpcs.serge678`; no password; script passes `ALTASTATA_USE_HPCS=1`). For **bob123** (password-based): `ACCOUNT_NAME=amazon.rsa.bob123 ./containers/rag-example/pull-and-run-rag-s390x-from-icr.sh`. Optional env: `SSH_HOST`, `SSH_KEY`, `HF_LLM_MODEL=gpt2` (8 GB VMs). Account dir must exist on the server at `$REMOTE_ALTASTATA_ACCOUNTS/$ACCOUNT_NAME` (default `/root/.altastata/accounts/...`).


### PR DESCRIPTION
Follow-up after merged PR 62: README snippets referenced a variable not set in version.sh. RAG image tags use RAG_VERSION; Jupyter uses JUPYTER_VERSION. Docs now use RAG_VERSION with source ./version.sh from repo root.

- examples/rag-example/open_llm/README.md
- containers/jupyter/IBM-LINUXONE-S390X-SETUP.md