### PR TITLE
Use lower-layer caching for ML datasets

### DIFF
--- a/altastata/altastata_pytorch_dataset.py
+++ b/altastata/altastata_pytorch_dataset.py
@@ -7,7 +7,6 @@ import io
 import os
 import sys
 import json
-import collections
 from typing import Dict, Any
 from altastata.altastata_functions import AltaStataFunctions
 import fnmatch
@@ -59,10 +58,6 @@ class AltaStataPyTorchDataset(Dataset):
         print(f"account_id: {account_id}")
         
         self.account_id = account_id
-        self.file_content_cache = collections.OrderedDict()
-        self.cache_size_limit = 1024 * 1024 * 1024  # 1GB limit
-        self.current_cache_size = 0
-        self.max_file_size_for_cache = 16 * 1024 * 1024  # 16MB limit per file
 
         altastata_functions = _get_altastata_functions(account_id)
 
@@ -163,12 +158,6 @@ class AltaStataPyTorchDataset(Dataset):
     def _write_file(self, path: str, data: bytes) -> None:
         """Write bytes to a file using either AltaStataFunctions or local file operations."""
 
-        # Remove from cache if present
-        if path in self.file_content_cache:
-            self.current_cache_size -= len(self.file_content_cache[path])
-            del self.file_content_cache[path]
-            print(f"Worker {os.getpid()} - Removed {path} from cache")
-
         altastata_functions = _get_altastata_functions(self.account_id)
 
         if altastata_functions is not None:
@@ -184,42 +173,16 @@ class AltaStataPyTorchDataset(Dataset):
             with open(local_path, 'wb') as f:
                 f.write(data)
 
-    def _cache_put(self, path: str, data: bytes):
-        """Insert data into the LRU cache, evicting oldest entries if needed.
-
-        Skips caching if the data exceeds ``max_file_size_for_cache``.
-        Handles duplicate keys by removing the old entry first.
-        """
-        data_len = len(data)
-        if data_len > self.max_file_size_for_cache:
-            return
-
-        if path in self.file_content_cache:
-            self.current_cache_size -= len(self.file_content_cache.pop(path))
-
-        while self.current_cache_size + data_len > self.cache_size_limit and self.file_content_cache:
-            evicted_path, evicted_data = self.file_content_cache.popitem(last=False)
-            self.current_cache_size -= len(evicted_data)
-
-        self.file_content_cache[path] = data
-        self.current_cache_size += data_len
-
     def _read_file(self, path: str) -> bytes:
         """Read file bytes from cloud storage or local filesystem.
 
-        Checks the in-memory LRU cache first. On a cache miss, fetches
-        the file size via ``get_file_attribute`` then reads content via
-        ``get_buffer`` (which streams in 8 MB chunks for large files).
-        The result is cached for subsequent reads.
+        For cloud storage, Java owns the reusable chunk cache. Python reads
+        each requested file through ``get_buffer`` without keeping a second
+        whole-file cache in the dataset worker.
 
         Falls back to local file I/O when no AltaStata connection is
         registered for this account.
         """
-        # LRU cache hit — promote to most-recently-used
-        if path in self.file_content_cache:
-            self.file_content_cache.move_to_end(path)
-            return self.file_content_cache[path]
-
         altastata_functions = _get_altastata_functions(self.account_id)
 
         if altastata_functions is not None:
@@ -229,9 +192,7 @@ class AltaStataPyTorchDataset(Dataset):
                 size = int(size_str) if size_str else 0
             except (ValueError, TypeError):
                 size = 0
-            data = altastata_functions.get_buffer(path, None, 0, 4, size)
-            self._cache_put(path, data)
-            return data
+            return altastata_functions.get_buffer(path, None, 0, 4, size)
         else:
             local_path = str(self.root_dir / path)
             with open(local_path, 'rb') as f:

--- a/altastata/altastata_tensorflow_dataset.py
+++ b/altastata/altastata_tensorflow_dataset.py
@@ -1,4 +1,3 @@
-import collections
 import tensorflow as tf
 import numpy as np
 from pathlib import Path
@@ -42,10 +41,6 @@ class AltaStataTensorFlowDataset(tf.data.Dataset):
         print(f"account_id: {account_id}")
         
         self.account_id = account_id
-        self.file_content_cache = collections.OrderedDict()
-        self.cache_size_limit = 1024 * 1024 * 1024  # 1GB limit
-        self.current_cache_size = 0
-        self.max_file_size_for_cache = 16 * 1024 * 1024  # 16MB limit per file
         self.preprocess_fn = preprocess_fn
 
         altastata_functions = _get_altastata_functions(account_id)
@@ -110,46 +105,19 @@ class AltaStataTensorFlowDataset(tf.data.Dataset):
         """Returns the list of input datasets."""
         return []
 
-    def _cache_put(self, path: str, data: bytes):
-        """Insert data into the LRU cache, evicting oldest entries if needed.
-
-        Skips caching if the data exceeds ``max_file_size_for_cache``.
-        Handles duplicate keys by removing the old entry first.
-        """
-        data_len = len(data)
-        if data_len > self.max_file_size_for_cache:
-            return
-
-        if path in self.file_content_cache:
-            self.current_cache_size -= len(self.file_content_cache.pop(path))
-
-        while self.current_cache_size + data_len > self.cache_size_limit and self.file_content_cache:
-            evicted_path, evicted_data = self.file_content_cache.popitem(last=False)
-            self.current_cache_size -= len(evicted_data)
-
-        self.file_content_cache[path] = data
-        self.current_cache_size += data_len
-
     def _read_from_altastata(self, altastata_functions, path):
         """Read file bytes from AltaStata cloud storage.
 
-        Checks the in-memory LRU cache first. On a cache miss, fetches
-        the file size via ``get_file_attribute`` then reads content via
-        ``get_buffer`` (which streams in 8 MB chunks for large files).
-        The result is always cached for subsequent reads.
+        Java owns the reusable chunk cache. Python reads each requested file
+        through ``get_buffer`` without keeping a second whole-file cache in
+        the dataset worker.
         """
-        if path in self.file_content_cache:
-            self.file_content_cache.move_to_end(path)
-            return self.file_content_cache[path]
-
         size_str = altastata_functions.get_file_attribute(path, None, "size")
         try:
             size = int(size_str) if size_str else 0
         except (ValueError, TypeError):
             size = 0
-        data = altastata_functions.get_buffer(path, None, 0, 4, size)
-        self._cache_put(path, data)
-        return data
+        return altastata_functions.get_buffer(path, None, 0, 4, size)
 
     def _load_and_preprocess(self, file_path, label):
         """Load and preprocess a single sample."""
@@ -241,12 +209,6 @@ class AltaStataTensorFlowDataset(tf.data.Dataset):
 
     def _write_file(self, path: str, data: bytes) -> None:
         """Write bytes to a file using either AltaStataFunctions or local file operations."""
-        # Remove from cache if present
-        if path in self.file_content_cache:
-            self.current_cache_size -= len(self.file_content_cache[path])
-            del self.file_content_cache[path]
-            print(f"Worker {os.getpid()} - Removed {path} from cache")
-
         altastata_functions = _get_altastata_functions(self.account_id)
 
         if altastata_functions is not None:
@@ -265,7 +227,7 @@ class AltaStataTensorFlowDataset(tf.data.Dataset):
         """Read file bytes from cloud storage or local filesystem.
 
         Converts TensorFlow tensor paths to strings. Routes to
-        ``_read_from_altastata`` (with caching) when a cloud connection
+        ``_read_from_altastata`` when a cloud connection
         is available, otherwise reads from the local filesystem.
         """
         if tf.is_tensor(path):

--- a/containers/jupyter/Dockerfile.arm64
+++ b/containers/jupyter/Dockerfile.arm64
@@ -15,31 +15,21 @@ USER root
 RUN mkdir -p /opt/app-root/src && \
     chown -R ${NB_UID}:${NB_GID} /opt/app-root
 
-# Install only altastata and PyTorch
+# Install PyTorch and the local altastata checkout
 # Use setuptools<75 for pkg_resources (conda setuptools 82 lacks it for Python 3.13)
 # Note: torchaudio 2.5.1 not available for Python 3.13/ARM64; using latest compatible versions
 #
 # Split into three RUN steps so a Docker layer-cache only invalidates from the
 # changed step downward. PyTorch is ~2 GB to download — keep it in its own
-# layer so an altastata version bump doesn't force a re-pull.
-#
-# altastata is pinned via a build ARG so the layer's pip command text changes
-# whenever the version is bumped — this invalidates the cache for that one layer
-# without --no-cache. Single source of truth lives in setup.py: the build scripts
-# (containers/jupyter/build-all-images.sh, push-to-ghcr.sh) source version.sh
-# which auto-extracts ALTASTATA_PYPI_VERSION from setup.py and forwards it as
-# --build-arg ALTASTATA_VERSION. ARG default is intentionally empty: ad-hoc
-# `docker build .` then installs the latest from PyPI; the build script always
-# pins to setup.py's version, which is the canonical path.
+# layer so local altastata source changes don't force a re-pull.
 RUN pip install --no-cache-dir "setuptools<75"
 RUN pip install --no-cache-dir torch torchvision torchaudio
-ARG ALTASTATA_VERSION=
-RUN if [ -n "${ALTASTATA_VERSION}" ]; then \
-        pip install --no-cache-dir "altastata==${ALTASTATA_VERSION}" ; \
-    else \
-        echo "WARN: ALTASTATA_VERSION not set (build script overrides this). Installing latest from PyPI." && \
-        pip install --no-cache-dir altastata ; \
-    fi
+
+# Install AltaStata from this repository so local changes are testable before
+# publishing a wheel to PyPI.
+COPY setup.py pyproject.toml README.md /src/altastata-python-package/
+COPY altastata /src/altastata-python-package/altastata
+RUN pip install --no-cache-dir /src/altastata-python-package
 
 # Copy pytorch-example for reference
 COPY --chown=${NB_UID}:${NB_GID} examples/pytorch-example /opt/app-root/src/pytorch-example/


### PR DESCRIPTION
## Summary
- Remove PyTorch and TensorFlow dataset-level whole-file caches so cloud reads rely on the shared Java chunk cache.
- Update the ARM64 Jupyter image to install AltaStata from the local checkout for Mac testing before PyPI publication.
- Includes the existing openshift branch work for LinuxONE/Jupyter/RAG build scripts and docs since this branch diverged from main.

## Test plan
- Ran `python -m py_compile altastata/altastata_pytorch_dataset.py altastata/altastata_tensorflow_dataset.py`.
- Rebuilt `altastata/jupyter-datascience-arm64:latest` and `:2026c_latest` locally.
- Recreated the local Jupyter container and verified it was healthy on port 8888.
- Verified inside the rebuilt/running image that PyTorch and TensorFlow dataset files no longer contain `file_content_cache`, `_cache_put`, or `OrderedDict`.

Made with [Cursor](https://cursor.com)