### PR TITLE
Bump altastata to 0.1.29

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='altastata',
-    version='0.1.28',
+    version='0.1.29',
     author='Serge Vilvovsky',
     author_email='serge.vilvovsky@altastata.com',
     description='A Python package for Altastata data processing and machine learning integration',


### PR DESCRIPTION
## Summary

Bumps `setup.py` version to **0.1.29** to match the wheel and source distribution already published on [PyPI](https://pypi.org/project/altastata/).

## Context

This release aligns the repository metadata with PyPI **0.1.29**, which ships the rebuilt AltaStata Hadoop shadow JAR and related dependency JARs. Docker images tagged `2026c_latest` were rebuilt separately for GHCR (Jupyter amd64 consumes this version from PyPI; arm64 uses the packaged tree from checkout).

## Checklist

- [x] Version matches published PyPI release


Made with [Cursor](https://cursor.com)