### PR TITLE
ui(js-grpc-playground): AttributesService and SharingService side by side

### DIFF
--- a/tests/js-grpc-ui/index.html
+++ b/tests/js-grpc-ui/index.html
@@ -134,9 +134,10 @@
     </div>
   </div>
 
-  <h2>AttributesService (Built-in attributes)</h2>
+  <h2>Attributes + Sharing</h2>
   <div class="grid">
     <div class="card">
+      <h3>AttributesService (Built-in attributes)</h3>
       <p class="hint">
         For this workflow, use <code>size</code> and <code>readers</code>.
         <code>eTag</code> / <code>s3metadata</code> are mainly for S3 gateway flows.
@@ -160,11 +161,8 @@
         <button id="delAttrBtn">DeleteAttribute (custom only)</button>
       </div>
     </div>
-  </div>
-
-  <h2>SharingService (Readers)</h2>
-  <div class="grid">
     <div class="card">
+      <h3>SharingService (Readers)</h3>
       <div class="row">
         <label for="readersInput">Readers (comma-separated)</label>
         <input id="readersInput" placeholder="user1,user2" />


### PR DESCRIPTION
Layout-only change to the gRPC-Web test playground (tests/js-grpc-ui/index.html): AttributesService and SharingService now render side by side in a shared two-column grid, stacking on narrow screens.

No package/version change; no Docker rebuild.

Made with [Cursor](https://cursor.com)