### PR TITLE
feat: bundle AltaStata Console SPA and bump altastata to 0.1.33

### DIFF
--- a/README-developer.md
+++ b/README-developer.md
@@ -1,4 +1,6 @@
-# AltaStata Python Package Developer Guide v0.1.15
+# AltaStata Python Package Developer Guide
+
+> Package version is tracked in `setup.py` (`pip show altastata` to inspect).
 
 ## Prerequisites
 

--- a/README-developer.md
+++ b/README-developer.md
@@ -2,35 +2,70 @@
 
 ## Prerequisites
 
-### JAR Files Setup
-1. Ensure you have the required JAR files in the `altastata/lib` directory:
-   ```bash
-   # For Windows example:
-   cp /c/Users/serge/AppData/Local/Packages/PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0/LocalCache/local-packages/share/py4j/py4j0.10.9.8.jar altastata/lib/
-   ```
+### Bundled artifacts setup
 
-2. Build and copy the AltaStata JARs:
-   ```bash
-   # Build gRPC artifact used by Python runtime
-   ./gradlew :altastata-grpc:shadowJar
+The wheel ships with two binary artifacts that this repo deliberately does
+not commit to git:
 
-   # Copy shared runtime jar (used by both Py4J classpath and gRPC auto-start)
+- `altastata/lib/altastata-grpc-<ver>-uber.jar` (built from `mycloud/altastata-grpc`)
+- `altastata/lib/altastata-console-static/` (built from `altastata-console/frontend`)
+
+Only `altastata/lib/py4j0.10.9.5.jar` is tracked in git, since it is a fixed
+upstream artifact rather than something we build. Everything else under
+`altastata/lib/` is gitignored (`lib/` rule in `.gitignore`) and must be
+populated locally before `pip install -e .` or `python -m build`.
+
+#### Quick start (recommended)
+
+Run the helper script — it builds both artifacts in one shot and stages
+them under `altastata/lib/`:
+
+```bash
+bash scripts/build-bundled-artifacts.sh
+```
+
+The script assumes the sibling layout `mycloud/` and `altastata-console/`
+next to this repo. Override with `ALTASTATA_MYCLOUD_DIR` /
+`ALTASTATA_CONSOLE_DIR` if your layout differs, or pass `SKIP_GRPC=1` /
+`SKIP_UI=1` to leave one side untouched.
+
+#### Manual fallback
+
+If you prefer to drive each build yourself:
+
+1. Build the gRPC uber jar in `mycloud/altastata-grpc`:
+   ```bash
+   (cd ../mycloud && ./gradlew :altastata-grpc:shadowJar)
    cp ../mycloud/altastata-grpc/build/libs/altastata-grpc-*-uber.jar altastata/lib/
    ```
 
-3. Verify JAR integrity:
+2. Build the Console SPA in `altastata-console/frontend`:
    ```bash
-   # Check if py4j JAR is valid
-   jar tf altastata/lib/py4j0.10.9.5.jar | grep GatewayServer
-   
-   # If corrupted, download a fresh copy
-   wget https://repo1.maven.org/maven2/net/sf/py4j/py4j/0.10.9.5/py4j-0.10.9.5.jar -O altastata/lib/py4j0.10.9.5.jar
+   (cd ../altastata-console/frontend && npm install && npm run build)
+   rm -rf altastata/lib/altastata-console-static
+   mkdir -p altastata/lib/altastata-console-static
+   cp -R ../altastata-console/frontend/dist/. altastata/lib/altastata-console-static/
    ```
 
-4. Run server from Python package (no Gradle needed):
+3. Verify py4j integrity (only relevant if you suspect corruption):
+   ```bash
+   jar tf altastata/lib/py4j0.10.9.5.jar | grep GatewayServer
+   # If corrupted, fetch a fresh copy
+   wget https://repo1.maven.org/maven2/net/sf/py4j/py4j/0.10.9.5/py4j-0.10.9.5.jar \
+        -O altastata/lib/py4j0.10.9.5.jar
+   ```
+
+4. Run the server (Java + bundled SPA on the same port):
    ```bash
    altastata-grpc-server
+   # gRPC + UI both on http://127.0.0.1:9877
    ```
+
+   The launcher exports `ALTASTATA_WEB_UI_DIR` automatically when the
+   bundled `altastata/lib/altastata-console-static/` is present, so the Java
+   gRPC gateway serves the SPA from the same port. Set
+   `ALTASTATA_WEB_UI_DIR=` (empty) before running to disable the UI and
+   keep gRPC-only routing for legacy testing.
 
 ### Logging Configuration
 - To customize logging, copy and modify the logback configuration:

--- a/altastata/grpc_client.py
+++ b/altastata/grpc_client.py
@@ -677,6 +677,7 @@ def _start_local_grpc_service(
     process = subprocess.Popen(
         list(resolved_command),
         cwd=resolved_working_dir,
+        env=_build_grpc_subprocess_env(),
         stdout=subprocess.PIPE if stream_logs else subprocess.DEVNULL,
         stderr=subprocess.PIPE if stream_logs else subprocess.DEVNULL,
     )
@@ -739,6 +740,52 @@ def _find_bundled_grpc_uber_jar() -> Optional[str]:
     if not candidates:
         return None
     return candidates[-1]
+
+
+def _build_grpc_subprocess_env() -> Dict[str, str]:
+    """
+    Environment dict to hand to ``subprocess.Popen`` when launching the Java
+    gRPC gateway from Python.
+
+    Inherits the parent environment so callers can keep influencing Java
+    tuning via ``JAVA_OPTS`` and similar, then exports
+    ``ALTASTATA_WEB_UI_DIR`` pointing at the bundled SPA bundle (when one is
+    present in this wheel) so the Java gateway also serves the AltaStata
+    Console UI on the gRPC port. The variable is set only if the caller has
+    not already chosen a value, leaving room for explicit overrides during
+    development or testing — including ``ALTASTATA_WEB_UI_DIR=`` to disable
+    the UI entirely.
+    """
+    env = os.environ.copy()
+    if not env.get("ALTASTATA_WEB_UI_DIR"):
+        ui_dir = _find_bundled_console_ui_dir()
+        if ui_dir is not None:
+            env["ALTASTATA_WEB_UI_DIR"] = ui_dir
+            print(f"Bundled AltaStata Console UI: {ui_dir}")
+    return env
+
+
+def _find_bundled_console_ui_dir() -> Optional[str]:
+    """
+    Resolve the AltaStata Console SPA bundle that ships next to the gRPC jar.
+
+    Returns the absolute path to ``altastata/lib/altastata-console-static`` if
+    it exists and contains an ``index.html``, otherwise None. The directory is
+    optional: wheels built without ``scripts/build-bundled-artifacts.sh`` (or
+    builds where ``SKIP_UI=1`` was passed) simply will not have it, and the
+    Java gRPC gateway falls back to gRPC-only routing.
+    """
+    try:
+        ui_dir = pkg_resources.resource_filename(
+            "altastata", "lib/altastata-console-static"
+        )
+    except Exception:
+        return None
+    if not os.path.isdir(ui_dir):
+        return None
+    if not os.path.isfile(os.path.join(ui_dir, "index.html")):
+        return None
+    return os.path.abspath(ui_dir)
 
 
 def _build_bundled_grpc_classpath(bundled_uber_jar: str) -> str:

--- a/altastata/grpc_server.py
+++ b/altastata/grpc_server.py
@@ -3,7 +3,10 @@ import shlex
 import subprocess
 import sys
 
-from .grpc_client import _resolve_local_grpc_startup_command
+from .grpc_client import (
+    _build_grpc_subprocess_env,
+    _resolve_local_grpc_startup_command,
+)
 
 
 def main() -> int:
@@ -23,7 +26,9 @@ def main() -> int:
         print("command:", shlex.join(command))
         return 0
 
-    process = subprocess.Popen(command, cwd=working_dir)
+    # Reuse the same env builder as the in-process launcher so the bundled
+    # AltaStata Console SPA (when present) is served on the same port as gRPC.
+    process = subprocess.Popen(command, cwd=working_dir, env=_build_grpc_subprocess_env())
     try:
         return process.wait()
     except KeyboardInterrupt:

--- a/scripts/build-bundled-artifacts.sh
+++ b/scripts/build-bundled-artifacts.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Build the binary artifacts that ship inside the altastata wheel.
+#
+# Why this exists:
+#   The altastata Python package ships two binary artifacts that this repo
+#   does not store in git:
+#     1. altastata-grpc-<ver>-uber.jar  (built from sibling mycloud/altastata-grpc)
+#     2. altastata/lib/altastata-console-static/  (built from sibling altastata-console)
+#   Both are deliberately gitignored under altastata/lib/ so the repo stays
+#   text-only. They are populated locally before `python -m build` so they
+#   end up inside the wheel published to PyPI.
+#
+# Usage:
+#   bash scripts/build-bundled-artifacts.sh
+#
+# Optional environment variables:
+#   ALTASTATA_MYCLOUD_DIR   override path to the mycloud checkout
+#                           (default: ../mycloud relative to this repo)
+#   ALTASTATA_CONSOLE_DIR   override path to the altastata-console checkout
+#                           (default: ../altastata-console relative to this repo)
+#   SKIP_GRPC=1             skip the altastata-grpc Gradle build (use existing
+#                           altastata-grpc-*-uber.jar already present in lib/)
+#   SKIP_UI=1               skip the altastata-console npm build (use existing
+#                           altastata/lib/altastata-console-static/ contents)
+#
+# What this does NOT do:
+#   - It does not commit anything. The point is to populate altastata/lib/
+#     locally so subsequent `pip install -e .` or `python -m build` picks
+#     the artifacts up via setup.py's package_data globs.
+#   - It does not touch py4j0.10.9.5.jar (the only jar this repo intentionally
+#     tracks) or the Bouncy Castle jars that already live under altastata/lib/.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB_DIR="$PKG_DIR/altastata/lib"
+STATIC_DIR="$LIB_DIR/altastata-console-static"
+
+MYCLOUD_DIR="${ALTASTATA_MYCLOUD_DIR:-$(cd "$PKG_DIR/../mycloud" 2>/dev/null && pwd || true)}"
+CONSOLE_DIR="${ALTASTATA_CONSOLE_DIR:-$(cd "$PKG_DIR/../altastata-console" 2>/dev/null && pwd || true)}"
+
+mkdir -p "$LIB_DIR"
+
+if [[ -z "${SKIP_GRPC:-}" ]]; then
+    if [[ -z "$MYCLOUD_DIR" || ! -d "$MYCLOUD_DIR" ]]; then
+        echo "ERROR: mycloud directory not found." >&2
+        echo "       Set ALTASTATA_MYCLOUD_DIR or place mycloud next to this repo." >&2
+        exit 1
+    fi
+    echo "==> Building altastata-grpc uber jar in $MYCLOUD_DIR"
+    (cd "$MYCLOUD_DIR" && ./gradlew :altastata-grpc:shadowJar)
+
+    UBER_JAR="$(ls -1 "$MYCLOUD_DIR"/altastata-grpc/build/libs/altastata-grpc-*-uber.jar 2>/dev/null | tail -1 || true)"
+    if [[ -z "$UBER_JAR" || ! -f "$UBER_JAR" ]]; then
+        echo "ERROR: no altastata-grpc-*-uber.jar produced under $MYCLOUD_DIR/altastata-grpc/build/libs/" >&2
+        exit 1
+    fi
+
+    # Remove any previously-staged uber jar so we never ship two side by side
+    # (the launcher classpath would otherwise pick the older version arbitrarily).
+    find "$LIB_DIR" -maxdepth 1 -name 'altastata-grpc-*-uber.jar' -print -delete
+    cp "$UBER_JAR" "$LIB_DIR/"
+    echo "    copied $(basename "$UBER_JAR") -> altastata/lib/"
+else
+    echo "==> SKIP_GRPC=1, leaving altastata-grpc uber jar untouched"
+fi
+
+if [[ -z "${SKIP_UI:-}" ]]; then
+    if [[ -z "$CONSOLE_DIR" || ! -d "$CONSOLE_DIR" ]]; then
+        echo "ERROR: altastata-console directory not found." >&2
+        echo "       Set ALTASTATA_CONSOLE_DIR or place altastata-console next to this repo." >&2
+        exit 1
+    fi
+    echo "==> Building altastata-console SPA in $CONSOLE_DIR/frontend"
+    (cd "$CONSOLE_DIR/frontend" && npm install --no-audit --no-fund && npm run build)
+
+    DIST_DIR="$CONSOLE_DIR/frontend/dist"
+    if [[ ! -f "$DIST_DIR/index.html" ]]; then
+        echo "ERROR: $DIST_DIR/index.html missing after npm run build" >&2
+        exit 1
+    fi
+
+    rm -rf "$STATIC_DIR"
+    mkdir -p "$STATIC_DIR"
+    cp -R "$DIST_DIR"/. "$STATIC_DIR"/
+    echo "    copied $DIST_DIR/* -> altastata/lib/altastata-console-static/"
+else
+    echo "==> SKIP_UI=1, leaving altastata-console-static untouched"
+fi
+
+echo
+echo "==> altastata/lib/ contents:"
+ls -1 "$LIB_DIR" | sed 's/^/    /'
+if [[ -d "$STATIC_DIR" ]]; then
+    echo "==> altastata/lib/altastata-console-static/ summary:"
+    if [[ -f "$STATIC_DIR/VERSION" ]]; then
+        echo "    VERSION = $(cat "$STATIC_DIR/VERSION")"
+    fi
+    echo "    files  = $(find "$STATIC_DIR" -type f | wc -l | tr -d ' ')"
+    echo "    bytes  = $(du -sh "$STATIC_DIR" | awk '{print $1}')"
+fi

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='altastata',
-    version='0.1.32',
+    version='0.1.33',
     author='Serge Vilvovsky',
     author_email='serge.vilvovsky@altastata.com',
     description='A Python package for Altastata data processing and machine learning integration',
@@ -15,7 +15,20 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     package_data={
-        'altastata': ['lib/*.jar', 'v1/*.py'],
+        # The lib/* glob captures the bundled altastata-grpc uber jar plus
+        # py4j and Bouncy Castle runtime jars. The two altastata-console-static
+        # patterns walk the SPA bundle one and two levels deep (Vite emits
+        # only an `assets/` subdir, so two levels is enough today; the second
+        # glob future-proofs against deeper nesting). All these binary
+        # artifacts are gitignored under altastata/lib/ and are populated
+        # locally by scripts/build-bundled-artifacts.sh before
+        # `python -m build`.
+        'altastata': [
+            'lib/*.jar',
+            'v1/*.py',
+            'lib/altastata-console-static/*',
+            'lib/altastata-console-static/*/*',
+        ],
         '': ['proto/**/*.proto']
     },
     classifiers=[

--- a/tests/test_grpc_client.py
+++ b/tests/test_grpc_client.py
@@ -185,9 +185,12 @@ class GrpcClientTests(unittest.TestCase):
         from altastata.grpc_client import _start_local_grpc_service
         _start_local_grpc_service()
 
+        # env is built by _build_grpc_subprocess_env (covered separately) and
+        # is forwarded to Popen so the Java side can pick up the bundled SPA.
         mock_popen.assert_called_once_with(
             ["java", "-cp", "/tmp/a.jar:/tmp/b.jar:/tmp/altastata-grpc-1.0.0-uber.jar", "com.altastata.grpc.GrpcApplication"],
             cwd="/tmp",
+            env=unittest.mock.ANY,
             stdout=unittest.mock.ANY,
             stderr=unittest.mock.ANY,
         )
@@ -211,9 +214,76 @@ class GrpcClientTests(unittest.TestCase):
         mock_popen.assert_called_once_with(
             ["./gradlew", ":altastata-grpc:run"],
             cwd="/work/mycloud",
+            env=unittest.mock.ANY,
             stdout=unittest.mock.ANY,
             stderr=unittest.mock.ANY,
         )
+
+    @patch("altastata.grpc_client._find_bundled_console_ui_dir")
+    def test_build_subprocess_env_exports_ui_dir_when_bundle_present(
+        self, mock_find_ui
+    ):
+        mock_find_ui.return_value = "/wheel/altastata/lib/altastata-console-static"
+
+        from altastata.grpc_client import _build_grpc_subprocess_env
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ALTASTATA_WEB_UI_DIR", None)
+            env = _build_grpc_subprocess_env()
+
+        self.assertEqual(
+            env["ALTASTATA_WEB_UI_DIR"],
+            "/wheel/altastata/lib/altastata-console-static",
+        )
+
+    @patch("altastata.grpc_client._find_bundled_console_ui_dir")
+    def test_build_subprocess_env_skips_ui_dir_when_no_bundle(self, mock_find_ui):
+        mock_find_ui.return_value = None
+
+        from altastata.grpc_client import _build_grpc_subprocess_env
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ALTASTATA_WEB_UI_DIR", None)
+            env = _build_grpc_subprocess_env()
+
+        self.assertNotIn("ALTASTATA_WEB_UI_DIR", env)
+
+    @patch("altastata.grpc_client._find_bundled_console_ui_dir")
+    def test_build_subprocess_env_respects_caller_override(self, mock_find_ui):
+        # If the caller explicitly set the variable (even to a different
+        # path, or to empty to disable), the bundled lookup must not
+        # silently override it.
+        mock_find_ui.return_value = "/wheel/altastata/lib/altastata-console-static"
+
+        from altastata.grpc_client import _build_grpc_subprocess_env
+        with patch.dict(os.environ, {"ALTASTATA_WEB_UI_DIR": "/custom/path"}):
+            env = _build_grpc_subprocess_env()
+
+        self.assertEqual(env["ALTASTATA_WEB_UI_DIR"], "/custom/path")
+        mock_find_ui.assert_not_called()
+
+    def test_find_bundled_console_ui_dir_returns_none_for_missing_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            empty_pkg = os.path.join(tmp, "altastata", "lib")
+            os.makedirs(empty_pkg)
+            with patch(
+                "altastata.grpc_client.pkg_resources.resource_filename",
+                return_value=os.path.join(empty_pkg, "altastata-console-static"),
+            ):
+                from altastata.grpc_client import _find_bundled_console_ui_dir
+                self.assertIsNone(_find_bundled_console_ui_dir())
+
+    def test_find_bundled_console_ui_dir_returns_path_when_index_html_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ui_dir = os.path.join(tmp, "altastata-console-static")
+            os.makedirs(ui_dir)
+            with open(os.path.join(ui_dir, "index.html"), "w") as f:
+                f.write("<html></html>")
+            with patch(
+                "altastata.grpc_client.pkg_resources.resource_filename",
+                return_value=ui_dir,
+            ):
+                from altastata.grpc_client import _find_bundled_console_ui_dir
+                self.assertEqual(_find_bundled_console_ui_dir(), os.path.abspath(ui_dir))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

The `altastata` wheel now ships the AltaStata Console UI alongside the gRPC runtime, so `altastata-grpc-server` (or any `AltaStataGrpcClient` auto-launch) serves both gRPC and the React SPA on a single port (`9877`) once the Python launcher exports `ALTASTATA_WEB_UI_DIR`.

## What changes

### Code

- `altastata/grpc_client.py`
  - New `_find_bundled_console_ui_dir()` helper, mirroring `_find_bundled_grpc_uber_jar`, that resolves `altastata/lib/altastata-console-static` when it exists and contains `index.html`.
  - New `_build_grpc_subprocess_env()` helper. Copies the parent env, then sets `ALTASTATA_WEB_UI_DIR` only when the caller has not set it, so users can override or disable (`ALTASTATA_WEB_UI_DIR=`) the bundled UI for testing.
  - `_start_local_grpc_service` passes `env=_build_grpc_subprocess_env()` to `subprocess.Popen`.
- `altastata/grpc_server.py`
  - The `console_scripts` entry point uses the same env helper, so the CLI flow has the same UI auto-discovery as the in-process auto-launch.

### Packaging

- `setup.py`
  - Version bump `0.1.32` -> `0.1.33` (additive, backwards compatible).
  - `package_data` picks up `lib/altastata-console-static/*` and `lib/altastata-console-static/*/*`.

### Tooling (no committed binaries)

- New `scripts/build-bundled-artifacts.sh`
  - One-shot helper that builds `altastata-grpc-*-uber.jar` (Gradle in sibling `mycloud`) and the Console SPA (npm in sibling `altastata-console`), then stages both under `altastata/lib/`.
  - Honours `ALTASTATA_MYCLOUD_DIR` / `ALTASTATA_CONSOLE_DIR` overrides and `SKIP_GRPC=1` / `SKIP_UI=1` escape hatches.
- The produced binaries remain gitignored under `altastata/lib/` via the existing `.gitignore` `lib/` rule. No committed binaries, consistent with how the gRPC uber jar already worked.

### Tests

- Existing two `_start_local_grpc_service` tests updated to tolerate the new `env=ANY` kwarg in the `Popen` call.
- Five new tests cover the helper precedence rules:
  - env exports the bundled UI dir when present;
  - env skips the var when no bundle is found;
  - env respects an explicit caller override (does not even probe for a bundled dir);
  - `_find_bundled_console_ui_dir` returns `None` for missing dirs;
  - `_find_bundled_console_ui_dir` returns the absolute path when `index.html` is present.
- `python -m unittest tests.test_grpc_client -v` -> 13 tests pass.

### Docs

- `README-developer.md` "JAR Files Setup" rewritten as "Bundled artifacts setup": explains why binary artifacts are gitignored, recommends `scripts/build-bundled-artifacts.sh`, and keeps the manual fallback for power users.

## Test plan

- [x] `bash scripts/build-bundled-artifacts.sh` succeeds and produces `altastata-grpc-1.1.0-uber.jar` + `altastata/lib/altastata-console-static/VERSION` = `0.2.0`.
- [x] `pip install -e .` installs `altastata-0.1.33`.
- [x] `altastata-grpc-server` logs `Bundled AltaStata Console UI: ...`; Java side logs `Serving static UI from ... on the gRPC gateway port`.
- [x] `curl http://127.0.0.1:9877/` -> `200 text/html` (393 bytes).
- [x] `curl http://127.0.0.1:9877/VERSION` -> `0.2.0`.
- [x] gRPC-Web POST on the same port still returns `200` + `grpc-status` header (RPC routing intact).
- [x] Manual browser smoke: SPA loads, account `amazon.rsa.bob123` displayed in title.

## Known follow-up (not in this PR)

When the user has not yet bootstrapped (no password set), `listDir("/")` fails with `FAILED_PRECONDITION: User is not initialized` and the React app currently shows an empty Miller-columns grid plus a stale "Select a file to preview" message - misleading. A separate altastata-console PR will surface a "set the password in Settings" banner for that state. This is purely a UI affordance; the transport itself works.

## Depends on

- altastata-grpc bumped to 1.1.0 (mycloud PR #170)
- altastata-console frontend bumped to 0.2.0, emits `dist/VERSION` (altastata-console PR #6)

These are already in flight; this PR's wheel will pick them up automatically once the build script is rerun against the merged commits.
