### PR TITLE
chore(jupyter): bump JUPYTER_VERSION 2026c -> 2026d, expose Console UI port

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ altastata-grpc-server
 python -m altastata.grpc_server
 ```
 
+The launcher binds gRPC to `127.0.0.1:9877` and, when the wheel ships with a
+bundled AltaStata Console SPA at `altastata/lib/altastata-console-static/`,
+serves the SPA from the same port. Open <http://127.0.0.1:9877> in a browser
+to get a Finder-style file manager with auto-refresh on `SHARE` / `DELETE`
+events from other users (see `mycloud/altastata-grpc/EventsService` and
+`altastata-console`). The launcher exports `ALTASTATA_WEB_UI_DIR`
+automatically; set `ALTASTATA_WEB_UI_DIR=` to disable the UI and keep the
+port gRPC-only.
+
 ## PyTorch & TensorFlow Integration
 
 ```python

--- a/containers/confidential-gke/jupyter-deployment.yaml
+++ b/containers/confidential-gke/jupyter-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: jupyter-datascience
-        image: ghcr.io/sergevil/altastata/jupyter-datascience-amd64:2026c_latest
+        image: ghcr.io/sergevil/altastata/jupyter-datascience-amd64:2026d_latest
         ports:
         - containerPort: 8888
         env:

--- a/containers/jupyter/README-Docker.md
+++ b/containers/jupyter/README-Docker.md
@@ -53,6 +53,7 @@ The Altastata Python Package system consists of a single Jupyter DataScience env
 | **Service** | **Description** | **Port** | **Image** |
 |-------------|-----------------|----------|-----------|
 | **Jupyter DataScience** | Jupyter Lab with PyTorch, TensorFlow, and Altastata integration | 8888 | `altastata/jupyter-datascience` |
+| **AltaStata Console (optional)** | Browser file manager + gRPC-Web gateway (`altastata-grpc-server`); same Java process serves both gRPC and the bundled SPA | 9877 | (in-image; no separate image) |
 
 ## Multi-Architecture Support
 
@@ -118,6 +119,11 @@ docker compose -f containers/jupyter/docker-compose.yml up -d
 # 3. Access Jupyter Lab at http://localhost:8888/lab
 # Get the token from logs: docker logs altastata-jupyter 2>&1 | grep -E "127.0.0.1:8888|token"
 # Or: docker exec altastata-jupyter jupyter server list
+
+# 4. (Optional) Start the AltaStata Console UI on port 9877
+docker exec -d altastata-jupyter bash -lc 'altastata-grpc-server > /tmp/grpc-server.log 2>&1'
+# Then open http://localhost:9877 in a browser. The same port serves both the
+# SPA and the gRPC-Web API; the launcher exports ALTASTATA_WEB_UI_DIR for you.
 ```
 
 ### Option 2: Use Pre-built GHCR Images

--- a/containers/jupyter/README-ICR-BUILD-AND-PUSH.md
+++ b/containers/jupyter/README-ICR-BUILD-AND-PUSH.md
@@ -13,7 +13,7 @@ then tagging and pushing the s390x image to IBM Container Registry (ICR).
 
 `version.sh` exposes two image tags (different release cadences):
 
-- `JUPYTER_VERSION` (currently `2026c_latest`) — used for `jupyter-datascience-{arm64,amd64,s390x}`.
+- `JUPYTER_VERSION` (currently `2026d_latest`) — used for `jupyter-datascience-{arm64,amd64,s390x}`.
 - `RAG_VERSION` (currently `2026g_latest`) — used for `rag-open-llm-s390x`. The `:${RAG_VERSION}_zdnn` variant is the research/zDNN-on build; the plain tag is the default CPU build.
 
 Source `version.sh` once and the rest of these examples just use `${JUPYTER_VERSION}` / `${RAG_VERSION}`.
@@ -106,7 +106,7 @@ docker buildx build --platform linux/s390x -f containers/rag-example/Dockerfile.
 
 ### Tag and push RAG s390x to ICR
 
-Uses **`RAG_VERSION`** from `version.sh` (currently **`2026g_latest`** — different from Jupyter’s **`JUPYTER_VERSION`** / `2026c_latest`).
+Uses **`RAG_VERSION`** from `version.sh` (currently **`2026g_latest`** — different from Jupyter’s **`JUPYTER_VERSION`** / `2026d_latest`).
 
 **Push from server** (image was built with `build-rag-s390x-on-server.sh`):
 ```bash

--- a/containers/jupyter/docker-compose.yml
+++ b/containers/jupyter/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     container_name: altastata-jupyter
     ports:
       - "8888:8888"
+      - "9877:9877"
     volumes:
       - ../../examples/pytorch-example:/home/jovyan/pytorch-example
       - ../../examples/tensorflow-example:/home/jovyan/tensorflow-example

--- a/version.sh
+++ b/version.sh
@@ -20,7 +20,7 @@
 # work. Separating the tags keeps each image's history truthful and avoids
 # end-user confusion ("did Jupyter change between 2026e and 2026g?" — no).
 
-JUPYTER_VERSION="2026c_latest"
+JUPYTER_VERSION="2026d_latest"
 RAG_VERSION="2026h_latest"
 
 # Resolve repo root from this script's location so callers can `source version.sh`


### PR DESCRIPTION
## Summary

- Bump `JUPYTER_VERSION` from `2026c_latest` to `2026d_latest` in `version.sh`. The 2026c Jupyter image bundled an older `altastata-grpc` JAR and SPA that together swallowed cross-user `SHARE`/`DELETE` events (the gRPC `EventsService.Subscribe` handler blocked the Armeria event-loop, so `onNext()` never reached the browser). The 2026d image content embeds the fixes from [SergeVil/mycloud#172](https://github.com/SergeVil/mycloud/pull/172) and [SergeVil/altastata-console#11](https://github.com/SergeVil/altastata-console/pull/11) so the bundled UI auto-refreshes on share / revoke.
- `containers/jupyter/docker-compose.yml` now exposes `9877:9877` so the AltaStata Console SPA served by `altastata-grpc-server` inside the container is reachable from the host browser at `http://localhost:9877`.
- `README.md` (top-level) describes the bundled SPA on port 9877 and the live SHARE / DELETE auto-refresh.
- `containers/jupyter/README-Docker.md` gains a row in the service catalogue for the optional Console UI service and a Quick Start step showing how to start `altastata-grpc-server` inside the container.
- `containers/jupyter/README-ICR-BUILD-AND-PUSH.md` + `containers/confidential-gke/jupyter-deployment.yaml` move from `2026c_latest` to `2026d_latest`.

`altastata` wheel version stays at `0.1.33` — only the bundled artifacts (`altastata/lib/altastata-grpc-1.1.0-uber.jar` and `altastata/lib/altastata-console-static/`) have new content; the Python API surface is unchanged.

## Test plan

- [x] `python -m build` produces `altastata-0.1.33-{whl,tar.gz}` containing the new uber jar and SPA bundle.
- [x] `docker build -f containers/jupyter/Dockerfile.arm64 ...` produces an image where `pip show altastata` reports `0.1.33` and `altastata/lib/altastata-grpc-1.1.0-uber.jar` is present.
- [x] `docker compose -f containers/jupyter/docker-compose.yml up -d` recreates `altastata-jupyter` with both `8888:8888` and `9877:9877` exposed.
- [x] `docker exec -d altastata-jupyter bash -lc 'altastata-grpc-server > /tmp/grpc-server.log 2>&1'` brings up the gRPC + SPA on port 9877; `curl http://127.0.0.1:9877/` returns HTTP 200.
- [x] Manual end-to-end inside the container: `bob123 -> alice222` share triggers `event message {eventName: "SHARE", ...}` in the alice's UI log panel within ~1s, followed by an immediate `listDir` and a `~7s` follow-up `listDir` that picks up the file once `Finishing shot was processed`.

Plan after merge: build amd64 image, push both arm/amd64 images to `ghcr.io/sergevil/altastata/jupyter-datascience-{arm64,amd64}:2026d_latest`, and `twine upload dist/altastata-0.1.33.*` to PyPI.
