### PR TITLE
chore: bump altastata 0.1.33 -> 0.1.34 (preview Size: -1 -> real bytes)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='altastata',
-    version='0.1.33',
+    version='0.1.34',
     author='Serge Vilvovsky',
     author_email='serge.vilvovsky@altastata.com',
     description='A Python package for Altastata data processing and machine learning integration',


### PR DESCRIPTION
## Summary

Bump `altastata` to **0.1.34** so the wheel rebundles altastata-console SPA **0.2.1** (built from [SergeVil/altastata-console#12](https://github.com/SergeVil/altastata-console/pull/12)).

### Why

The 0.1.33 wheel bundled altastata-console 0.2.0 which rendered `Size: -1` in the preview pane for every selected file. The real cause was on the SPA side: `fetchFilePreviewMetadata` queried `getAttributes` on the bare cloud path plus `snapshotTime = parseVersionTimestamp(version)`. The Java gRPC service mapped that to a `java.lang.Long null`, Scala's `BoxesRunTime.unboxToLong(null)` silently yielded `0L`, and `CloudFile.getBestMatchingVersionAttributes(0L)` then never matched any real version's `createTime`. The Scala model treated that as "version not found" and substituted the stub string `"-1"` for the `size` attribute — exactly what the UI was rendering.

The 0.2.1 SPA sends BOTH the version suffix (`{cloudPath}✹{tag}_{createTime}`) AND the explicit `snapshotTime = parseVersionTimestamp(version)`. The first triggers the fast path in `AltaStataFileSystem.getFileAttributes` (it parses the CloudFile + version directly via `parseObjectPathIncludingVersion`), the second makes `getBestMatchingVersionAttributes(timestamp)` find that version deterministically.

### What's in this wheel

| Artifact | Version |
|---|---|
| `altastata/lib/altastata-console-static/VERSION` | `0.2.1` |
| `altastata/lib/altastata-grpc-1.1.0-uber.jar` | unchanged (1.1.0) |
| `altastata` Python API | unchanged |

### Docker images

`JUPYTER_VERSION` stays at `2026d_latest`. The 2026d Jupyter images are rebuilt in place (rolling tag) with `ALTASTATA_VERSION=0.1.34` so they also pick up the SPA fix without churning the Kubernetes manifests.

## Test plan

- [x] `python -m build` produces `altastata-0.1.34-{whl,tar.gz}` with `altastata-console-static/VERSION = 0.2.1` and `altastata-grpc-1.1.0-uber.jar`.
- [x] `twine upload` published to PyPI: https://pypi.org/project/altastata/0.1.34/
- [x] Manual smoke test (drop new SPA into running `altastata-jupyter` container, hard-refresh `:9877`, select a `.pth` file, confirm preview pane shows real byte count instead of `-1`).
- [ ] `docker buildx build --platform linux/amd64 -f containers/jupyter/Dockerfile.amd64 --build-arg ALTASTATA_VERSION=0.1.34 -t altastata/jupyter-datascience-amd64:2026d_latest .` succeeds.
- [ ] `docker build -f containers/jupyter/Dockerfile.arm64 --build-arg ALTASTATA_VERSION=0.1.34 -t altastata/jupyter-datascience-arm64:2026d_latest .` succeeds.
- [ ] `docker push ghcr.io/sergevil/altastata/jupyter-datascience-{amd64,arm64}:2026d_latest` overwrites the existing tag.
