### PR TITLE
chore(s390x): bump RAG_VERSION 2026h -> 2026i, fix grpcio build (openshift)

### DIFF
--- a/containers/jupyter/Dockerfile.s390x
+++ b/containers/jupyter/Dockerfile.s390x
@@ -8,16 +8,25 @@ LABEL org.opencontainers.image.source="https://github.com/altastata/altastata-py
 
 USER root
 
-# Install Java 17 and build dependencies for scientific Python packages
+# Install Java 17 and build dependencies for scientific Python packages.
+# openssl-devel is required to build grpcio from source against the system
+# OpenSSL — grpcio's bundled BoringSSL has broken s390x support in the
+# FIPS/spake2plus path (see GRPC_PYTHON_BUILD_SYSTEM_OPENSSL below).
 RUN dnf install -y java-17-openjdk-devel gcc gcc-c++ gcc-gfortran make openblas openblas-devel \
+    openssl-devel \
     libxml2-devel libxslt-devel \
     libjpeg-turbo-devel zlib-devel freetype-devel lcms2-devel libtiff-devel libwebp-devel openjpeg2-devel \
     zeromq-devel libsodium-devel && \
     dnf clean all
 
-# Set JAVA_HOME
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 ENV PATH="${PATH}:${JAVA_HOME}/bin"
+
+# grpcio's bundled BoringSSL fails to compile on s390x in 1.72+ (e.g.
+# third_party/boringssl-with-bazel/.../bn/internal.h: 'BN_ULONG' was not
+# declared). Link against the system OpenSSL (installed above) instead.
+# Build-time only; harmless at runtime.
+ENV GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True
 
 # Create jovyan user (UID 1001, same as AMD64 version)
 RUN useradd -m -u 1001 -g root -s /bin/bash jovyan

--- a/containers/jupyter/README-Docker.md
+++ b/containers/jupyter/README-Docker.md
@@ -29,9 +29,10 @@ This comprehensive guide covers building, running, and deploying the Altastata P
 
 The Docker image version is centrally managed in `version.sh`. To update the version across all scripts and configuration files:
 
-1. Edit `version.sh` and update the `VERSION` variable:
+1. Edit `version.sh` and update the relevant variable:
    ```bash
-   VERSION="2026b_latest"  # Change to your desired version
+   JUPYTER_VERSION="2026d_latest"   # Bump on real Jupyter image changes
+   RAG_VERSION="2026i_latest"       # Bump on RAG image changes (zDNN variant is :${RAG_VERSION}_zdnn)
    ```
 
 2. Run the update script to sync the version to all configuration files:
@@ -83,8 +84,9 @@ separately using `containers/jupyter/Dockerfile.s390x`.
 ### Usage (AMD64 + ARM64)
 
 ```bash
-# Pull image for your platform (version from version.sh, currently: 2026b_latest)
+# Pull image for your platform (version from version.sh, currently JUPYTER_VERSION=2026d_latest)
 source version.sh
+VERSION="${JUPYTER_VERSION}"
 
 # Apple Silicon (ARM64):
 docker pull ghcr.io/sergevil/altastata/jupyter-datascience-arm64:${VERSION}

--- a/containers/jupyter/README-ICR-BUILD-AND-PUSH.md
+++ b/containers/jupyter/README-ICR-BUILD-AND-PUSH.md
@@ -13,8 +13,8 @@ then tagging and pushing the s390x image to IBM Container Registry (ICR).
 
 `version.sh` exposes two image tags (different release cadences):
 
-- `JUPYTER_VERSION` (currently `2026c_latest`) — used for `jupyter-datascience-{arm64,amd64,s390x}`.
-- `RAG_VERSION` (currently `2026g_latest`) — used for `rag-open-llm-s390x`. The `:${RAG_VERSION}_zdnn` variant is the research/zDNN-on build; the plain tag is the default CPU build.
+- `JUPYTER_VERSION` (currently `2026d_latest`) — used for `jupyter-datascience-{arm64,amd64,s390x}`.
+- `RAG_VERSION` (currently `2026i_latest`) — used for `rag-open-llm-s390x`. The `:${RAG_VERSION}_zdnn` variant is the research/zDNN-on build; the plain tag is the default CPU build.
 
 Source `version.sh` once and the rest of these examples just use `${JUPYTER_VERSION}` / `${RAG_VERSION}`.
 
@@ -106,7 +106,7 @@ docker buildx build --platform linux/s390x -f containers/rag-example/Dockerfile.
 
 ### Tag and push RAG s390x to ICR
 
-Uses **`RAG_VERSION`** from `version.sh` (currently **`2026g_latest`** — different from Jupyter’s **`JUPYTER_VERSION`** / `2026c_latest`).
+Uses **`RAG_VERSION`** from `version.sh` (currently **`2026i_latest`** — different from Jupyter’s **`JUPYTER_VERSION`** / `2026d_latest`).
 
 **Push from server** (image was built with `build-rag-s390x-on-server.sh`):
 ```bash

--- a/containers/rag-example/Dockerfile.open_llm_s390x
+++ b/containers/rag-example/Dockerfile.open_llm_s390x
@@ -14,15 +14,25 @@ LABEL org.opencontainers.image.source="https://github.com/altastata/altastata-py
 
 USER root
 
-# Java for AltaStata; build deps for sentence-transformers, IBM zDNN (autotools), and llama-cpp-python (cmake + OpenBLAS + git)
+# Java for AltaStata; build deps for sentence-transformers, IBM zDNN (autotools), and llama-cpp-python (cmake + OpenBLAS + git).
+# openssl-devel is required to build grpcio from source against the system
+# OpenSSL — grpcio's bundled BoringSSL has broken s390x support in the
+# FIPS/spake2plus path (see GRPC_PYTHON_BUILD_SYSTEM_OPENSSL below).
 RUN dnf install -y java-17-openjdk-headless gcc gcc-c++ gcc-gfortran make \
     cmake openblas-devel git \
     autoconf automake libtool \
+    openssl-devel \
     libxml2-devel libxslt-devel \
     && dnf clean all
 
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 ENV PATH="${PATH}:${JAVA_HOME}/bin"
+
+# grpcio's bundled BoringSSL fails to compile on s390x in 1.72+ (e.g.
+# third_party/boringssl-with-bazel/.../bn/internal.h: 'BN_ULONG' was not
+# declared). Link against the system OpenSSL (installed above) instead.
+# Build-time only; harmless at runtime.
+ENV GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True
 
 # zDNN / NNPA (z16/z17) hardware acceleration is currently *off by default* —
 # field testing on z17 showed activating it via this image regresses query

--- a/containers/rag-example/build-rag-s390x-on-server.sh
+++ b/containers/rag-example/build-rag-s390x-on-server.sh
@@ -123,7 +123,7 @@ else
   "
 fi
 
-# Tagging strategy (RAG_VERSION comes from version.sh, currently 2026g_latest):
+# Tagging strategy (RAG_VERSION comes from version.sh, currently 2026i_latest):
 #   ENABLE_ZDNN=0 (default, end-user image) -> :latest AND :$RAG_VERSION
 #   ENABLE_ZDNN=1 (research-only, F16 + zDNN baked in) -> :${RAG_VERSION}_zdnn
 # The zDNN variant must NEVER claim :latest, otherwise an end user pulling the

--- a/examples/rag-example/open_llm/README.md
+++ b/examples/rag-example/open_llm/README.md
@@ -472,6 +472,8 @@ LLAMA_CPP_MODEL_REPO= \
   ./containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
 ```
 
+**Build-time gotcha — grpcio on s390x.** `grpcio >= 1.69` (added as a dep via `altastata` for the gRPC transport) ships with bundled BoringSSL, whose FIPS code path fails to compile on s390x (`error: 'BN_ULONG' was not declared in this scope`). Our s390x Dockerfiles (`containers/rag-example/Dockerfile.open_llm_s390x` and `containers/jupyter/Dockerfile.s390x`) install `openssl-devel` and set `ENV GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True` so the wheel builds against the system OpenSSL instead. Building `grpcio` from source on s390x adds **~10 min** to the image build; if you ever see the BoringSSL error after a `grpcio` major bump, the same env var is the workaround. See also IBM Z's [pytorch-on-z notes](https://github.com/IBM/ibmz-accelerated-for-pytorch) and grpc/grpc#37977.
+
 ### Simplest run on IBM Z (s390x) – no Docker build
 
 Run the RAG stack on 390 **without building any Docker images**: use Python on the s390x host and a **remote** LLM so you don’t need Ollama on 390.

--- a/version.sh
+++ b/version.sh
@@ -20,8 +20,8 @@
 # work. Separating the tags keeps each image's history truthful and avoids
 # end-user confusion ("did Jupyter change between 2026e and 2026g?" — no).
 
-JUPYTER_VERSION="2026c_latest"
-RAG_VERSION="2026h_latest"
+JUPYTER_VERSION="2026d_latest"
+RAG_VERSION="2026i_latest"
 
 # Resolve repo root from this script's location so callers can `source version.sh`
 # from any cwd. Falls back to the current dir if BASH_SOURCE isn't available.


### PR DESCRIPTION
Cherry-pick of #81 (`main`) onto `openshift`.

## Summary

- **Fix grpcio build on s390x.** `grpcio >= 1.69` ships bundled BoringSSL whose FIPS code path fails to compile on s390x (`error: 'BN_ULONG' was not declared in this scope`). Both the Jupyter and RAG s390x Dockerfiles now install `openssl-devel` and set `ENV GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True` so the wheel builds against the system OpenSSL instead. Adds ~10 min to the s390x image build.
- **Bump `RAG_VERSION`** `2026h_latest` → `2026i_latest` and **`JUPYTER_VERSION`** `2026c_latest` → `2026d_latest` in `version.sh` (the Jupyter bump mirrors what's already on `main`). Updates the version references in `containers/jupyter/README-Docker.md`, `containers/jupyter/README-ICR-BUILD-AND-PUSH.md`, and `containers/rag-example/build-rag-s390x-on-server.sh`.
- **Add a build-time troubleshooting callout** for future s390x maintainers in `examples/rag-example/open_llm/README.md` documenting the grpcio gotcha.

### Differences from #81 (main)

This branch resolves the cherry-pick conflicts (`version.sh`, `containers/jupyter/README-*.md`) by bringing `openshift` fully up to the same version pair as `main` (`JUPYTER=2026d_latest`, `RAG=2026i_latest`). Functionally identical to #81.

## Test plan

Same as #81 — built on LinuxONE from the same Dockerfile changes:

- [x] Pass 1 (non-zDNN): `altastata/jupyter-datascience-s390x:2026d_latest` + `altastata/rag-open-llm-s390x:2026i_latest`.
- [x] Pass 2 (zDNN): `altastata/rag-open-llm-s390x:2026i_latest_zdnn`.
- [x] Smoke-tested Jupyter Lab + AltaStata Console UI (ports 8888 / 9877).
- [x] Smoke-tested the non-zDNN RAG web app (port 8000).
- [ ] Push all three to `icr.io/altastata/...` once the new ICR API key is available.
- [ ] Smoke-test the zDNN RAG image.
