### PR TITLE
feat(grpc): migrate add_event_listener to EventsService.Watch; bump to 0.1.36

### DIFF
--- a/altastata/grpc_client.py
+++ b/altastata/grpc_client.py
@@ -567,30 +567,43 @@ class AltaStataGrpcClient:
             parallel_chunks=how_many_chunks_in_parallel,
         )
 
+    # Watch is the sole event RPC; FileSharedEvent / FileUnsharedEvent
+    # are translated back to the ('SHARE'|'DELETE', path) pair the old
+    # AltaStataEventListener / Py4J path used so existing user callbacks
+    # keep working unchanged. Other typed payloads (gap, session revoked)
+    # had no legacy equivalent and are simply skipped.
+    @staticmethod
+    def _legacy_pair(event):
+        which = event.WhichOneof("payload")
+        if which == "file_shared":
+            return ("SHARE", event.file_shared.file_path)
+        if which == "file_unshared":
+            return ("DELETE", event.file_unshared.file_id)
+        return None
+
     def subscribe_events(self):
-        req = self._events_pb2.SubscribeRequest()
-        for event in self._events_stub.Subscribe(req, metadata=self._metadata):
-            yield {"event_name": event.event_name, "data": event.data}
+        req = self._events_pb2.WatchRequest(since_sequence=0)
+        for event in self._events_stub.Watch(req, metadata=self._metadata):
+            pair = self._legacy_pair(event)
+            if pair is not None:
+                yield {"event_name": pair[0], "data": pair[1]}
 
     def add_event_listener(self, callback):
-        """
-        gRPC replacement for Py4J add_event_listener.
-        Starts a daemon thread that consumes Subscribe stream and invokes callback.
-        """
         stop_flag = {"stop": False}
         call_ref = {"call": None}
 
         def _worker():
             try:
-                req = self._events_pb2.SubscribeRequest()
-                call = self._events_stub.Subscribe(req, metadata=self._metadata)
+                req = self._events_pb2.WatchRequest(since_sequence=0)
+                call = self._events_stub.Watch(req, metadata=self._metadata)
                 call_ref["call"] = call
                 for event in call:
                     if stop_flag["stop"]:
                         break
-                    callback(event.event_name, event.data)
+                    pair = self._legacy_pair(event)
+                    if pair is not None:
+                        callback(*pair)
             except Exception:
-                # Match Py4J behavior: do not crash caller on background listener errors.
                 pass
 
         t = threading.Thread(target=_worker, daemon=True)
@@ -609,9 +622,7 @@ class AltaStataGrpcClient:
                     call.cancel()
 
     def remove_all_event_listeners(self):
-        # Cooperative stop; stream closes naturally when call finishes/cancelled.
         for t in self._listener_threads:
-            # best-effort no-op; handles returned by add_event_listener own stop flags
             _ = t
         self._listener_threads.clear()
 

--- a/altastata/v1/events_pb2.py
+++ b/altastata/v1/events_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x19\x61ltastata/v1/events.proto\x12\x0c\x61ltastata.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"&\n\x0cWatchRequest\x12\x16\n\x0esince_sequence\x18\x01 \x01(\x04\"\xd2\x02\n\x05\x45vent\x12\x10\n\x08sequence\x18\x01 \x01(\x04\x12/\n\x0boccurred_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x1b\n\x13origin_session_hash\x18\x03 \x01(\t\x12\x34\n\x0b\x66ile_shared\x18\n \x01(\x0b\x32\x1d.altastata.v1.FileSharedEventH\x00\x12\x38\n\rfile_unshared\x18\x0b \x01(\x0b\x32\x1f.altastata.v1.FileUnsharedEventH\x00\x12<\n\x0fsession_revoked\x18\x63 \x01(\x0b\x32!.altastata.v1.SessionRevokedEventH\x00\x12\x30\n\tevent_gap\x18\x64 \x01(\x0b\x32\x1b.altastata.v1.EventGapEventH\x00\x42\t\n\x07payload\"H\n\x0f\x46ileSharedEvent\x12\x0f\n\x07\x66ile_id\x18\x01 \x01(\t\x12\x11\n\tfile_path\x18\x02 \x01(\t\x12\x11\n\tshared_by\x18\x03 \x01(\t\"9\n\x11\x46ileUnsharedEvent\x12\x0f\n\x07\x66ile_id\x18\x01 \x01(\t\x12\x13\n\x0bunshared_by\x18\x02 \x01(\t\"}\n\x13SessionRevokedEvent\x12\x38\n\x06reason\x18\x01 \x01(\x0e\x32(.altastata.v1.SessionRevokedEvent.Reason\",\n\x06Reason\x12\n\n\x06LOGOUT\x10\x00\x12\x0b\n\x07\x45XPIRED\x10\x01\x12\t\n\x05\x41\x44MIN\x10\x02\"/\n\rEventGapEvent\x12\x1e\n\x16server_oldest_sequence\x18\x01 \x01(\x04\"\x12\n\x10SubscribeRequest\"0\n\x0c\x45ventMessage\x12\x12\n\nevent_name\x18\x01 \x01(\t\x12\x0c\n\x04\x64\x61ta\x18\x02 \x01(\t2\x96\x01\n\rEventsService\x12:\n\x05Watch\x12\x1a.altastata.v1.WatchRequest\x1a\x13.altastata.v1.Event0\x01\x12I\n\tSubscribe\x12\x1e.altastata.v1.SubscribeRequest\x1a\x1a.altastata.v1.EventMessage0\x01\x42)\n\x18\x63om.altastata.grpc.protoB\x0b\x45ventsProtoP\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x19\x61ltastata/v1/events.proto\x12\x0c\x61ltastata.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"&\n\x0cWatchRequest\x12\x16\n\x0esince_sequence\x18\x01 \x01(\x04\"\xd2\x02\n\x05\x45vent\x12\x10\n\x08sequence\x18\x01 \x01(\x04\x12/\n\x0boccurred_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x1b\n\x13origin_session_hash\x18\x03 \x01(\t\x12\x34\n\x0b\x66ile_shared\x18\n \x01(\x0b\x32\x1d.altastata.v1.FileSharedEventH\x00\x12\x38\n\rfile_unshared\x18\x0b \x01(\x0b\x32\x1f.altastata.v1.FileUnsharedEventH\x00\x12<\n\x0fsession_revoked\x18\x63 \x01(\x0b\x32!.altastata.v1.SessionRevokedEventH\x00\x12\x30\n\tevent_gap\x18\x64 \x01(\x0b\x32\x1b.altastata.v1.EventGapEventH\x00\x42\t\n\x07payload\"H\n\x0f\x46ileSharedEvent\x12\x0f\n\x07\x66ile_id\x18\x01 \x01(\t\x12\x11\n\tfile_path\x18\x02 \x01(\t\x12\x11\n\tshared_by\x18\x03 \x01(\t\"9\n\x11\x46ileUnsharedEvent\x12\x0f\n\x07\x66ile_id\x18\x01 \x01(\t\x12\x13\n\x0bunshared_by\x18\x02 \x01(\t\"}\n\x13SessionRevokedEvent\x12\x38\n\x06reason\x18\x01 \x01(\x0e\x32(.altastata.v1.SessionRevokedEvent.Reason\",\n\x06Reason\x12\n\n\x06LOGOUT\x10\x00\x12\x0b\n\x07\x45XPIRED\x10\x01\x12\t\n\x05\x41\x44MIN\x10\x02\"/\n\rEventGapEvent\x12\x1e\n\x16server_oldest_sequence\x18\x01 \x01(\x04\x32K\n\rEventsService\x12:\n\x05Watch\x12\x1a.altastata.v1.WatchRequest\x1a\x13.altastata.v1.Event0\x01\x42)\n\x18\x63om.altastata.grpc.protoB\x0b\x45ventsProtoP\x01\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -47,10 +47,6 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_SESSIONREVOKEDEVENT_REASON']._serialized_end=715
   _globals['_EVENTGAPEVENT']._serialized_start=717
   _globals['_EVENTGAPEVENT']._serialized_end=764
-  _globals['_SUBSCRIBEREQUEST']._serialized_start=766
-  _globals['_SUBSCRIBEREQUEST']._serialized_end=784
-  _globals['_EVENTMESSAGE']._serialized_start=786
-  _globals['_EVENTMESSAGE']._serialized_end=834
-  _globals['_EVENTSSERVICE']._serialized_start=837
-  _globals['_EVENTSSERVICE']._serialized_end=987
+  _globals['_EVENTSSERVICE']._serialized_start=766
+  _globals['_EVENTSSERVICE']._serialized_end=841
 # @@protoc_insertion_point(module_scope)

--- a/altastata/v1/events_pb2_grpc.py
+++ b/altastata/v1/events_pb2_grpc.py
@@ -31,21 +31,16 @@ class EventsServiceStub(object):
 
     See altastata-grpc/SESSION_AND_EVENTS_DESIGN.md §7 for the full model.
 
-    Two RPCs live in this file:
+    Watch is the only event RPC. Each session (each browser tab / each
+    AuthService.Login) opens exactly one Watch stream after Login. The server
+    delivers a typed Event stream with monotonic per-userName sequence
+    numbers, supports since_sequence-based replay from the in-memory ring
+    buffer, and emits EventGap when the requested cursor is older than the
+    buffer.
 
-    Watch     — NEW.  Per-session server-streaming RPC backed by EventBus.
-    Each session (each browser tab / each AuthService.Login) opens
-    exactly one Watch stream after Login. The server delivers a
-    typed Event stream with monotonic per-userName sequence
-    numbers, supports since_sequence-based replay from the
-    in-memory ring buffer, and emits EventGap when the requested
-    cursor is older than the buffer.
-
-    Subscribe — DEPRECATED. The pre-EventBus path that registers a listener
-    directly on AltaStataFileSystem and forwards untyped
-    (eventName, data) tuples. Kept for backwards compatibility
-    with the existing frontend; will be removed together with
-    EventMessage / SubscribeRequest in PR-6 of the design doc.
+    The pre-EventBus untyped Subscribe RPC was removed once both first-party
+    clients (Console UI and altastata-python-package) had switched to Watch;
+    see SESSION_AND_EVENTS_DESIGN.md §12 for the migration history.
     =============================================================================
 
     """
@@ -61,11 +56,6 @@ class EventsServiceStub(object):
                 request_serializer=altastata_dot_v1_dot_events__pb2.WatchRequest.SerializeToString,
                 response_deserializer=altastata_dot_v1_dot_events__pb2.Event.FromString,
                 _registered_method=True)
-        self.Subscribe = channel.unary_stream(
-                '/altastata.v1.EventsService/Subscribe',
-                request_serializer=altastata_dot_v1_dot_events__pb2.SubscribeRequest.SerializeToString,
-                response_deserializer=altastata_dot_v1_dot_events__pb2.EventMessage.FromString,
-                _registered_method=True)
 
 
 class EventsServiceServicer(object):
@@ -74,21 +64,16 @@ class EventsServiceServicer(object):
 
     See altastata-grpc/SESSION_AND_EVENTS_DESIGN.md §7 for the full model.
 
-    Two RPCs live in this file:
+    Watch is the only event RPC. Each session (each browser tab / each
+    AuthService.Login) opens exactly one Watch stream after Login. The server
+    delivers a typed Event stream with monotonic per-userName sequence
+    numbers, supports since_sequence-based replay from the in-memory ring
+    buffer, and emits EventGap when the requested cursor is older than the
+    buffer.
 
-    Watch     — NEW.  Per-session server-streaming RPC backed by EventBus.
-    Each session (each browser tab / each AuthService.Login) opens
-    exactly one Watch stream after Login. The server delivers a
-    typed Event stream with monotonic per-userName sequence
-    numbers, supports since_sequence-based replay from the
-    in-memory ring buffer, and emits EventGap when the requested
-    cursor is older than the buffer.
-
-    Subscribe — DEPRECATED. The pre-EventBus path that registers a listener
-    directly on AltaStataFileSystem and forwards untyped
-    (eventName, data) tuples. Kept for backwards compatibility
-    with the existing frontend; will be removed together with
-    EventMessage / SubscribeRequest in PR-6 of the design doc.
+    The pre-EventBus untyped Subscribe RPC was removed once both first-party
+    clients (Console UI and altastata-python-package) had switched to Watch;
+    see SESSION_AND_EVENTS_DESIGN.md §12 for the migration history.
     =============================================================================
 
     """
@@ -103,13 +88,6 @@ class EventsServiceServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
-    def Subscribe(self, request, context):
-        """DEPRECATED: untyped pre-EventBus listener path. Use Watch instead.
-        """
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
-
 
 def add_EventsServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -117,11 +95,6 @@ def add_EventsServiceServicer_to_server(servicer, server):
                     servicer.Watch,
                     request_deserializer=altastata_dot_v1_dot_events__pb2.WatchRequest.FromString,
                     response_serializer=altastata_dot_v1_dot_events__pb2.Event.SerializeToString,
-            ),
-            'Subscribe': grpc.unary_stream_rpc_method_handler(
-                    servicer.Subscribe,
-                    request_deserializer=altastata_dot_v1_dot_events__pb2.SubscribeRequest.FromString,
-                    response_serializer=altastata_dot_v1_dot_events__pb2.EventMessage.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -137,21 +110,16 @@ class EventsService(object):
 
     See altastata-grpc/SESSION_AND_EVENTS_DESIGN.md §7 for the full model.
 
-    Two RPCs live in this file:
+    Watch is the only event RPC. Each session (each browser tab / each
+    AuthService.Login) opens exactly one Watch stream after Login. The server
+    delivers a typed Event stream with monotonic per-userName sequence
+    numbers, supports since_sequence-based replay from the in-memory ring
+    buffer, and emits EventGap when the requested cursor is older than the
+    buffer.
 
-    Watch     — NEW.  Per-session server-streaming RPC backed by EventBus.
-    Each session (each browser tab / each AuthService.Login) opens
-    exactly one Watch stream after Login. The server delivers a
-    typed Event stream with monotonic per-userName sequence
-    numbers, supports since_sequence-based replay from the
-    in-memory ring buffer, and emits EventGap when the requested
-    cursor is older than the buffer.
-
-    Subscribe — DEPRECATED. The pre-EventBus path that registers a listener
-    directly on AltaStataFileSystem and forwards untyped
-    (eventName, data) tuples. Kept for backwards compatibility
-    with the existing frontend; will be removed together with
-    EventMessage / SubscribeRequest in PR-6 of the design doc.
+    The pre-EventBus untyped Subscribe RPC was removed once both first-party
+    clients (Console UI and altastata-python-package) had switched to Watch;
+    see SESSION_AND_EVENTS_DESIGN.md §12 for the migration history.
     =============================================================================
 
     """
@@ -173,33 +141,6 @@ class EventsService(object):
             '/altastata.v1.EventsService/Watch',
             altastata_dot_v1_dot_events__pb2.WatchRequest.SerializeToString,
             altastata_dot_v1_dot_events__pb2.Event.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-            _registered_method=True)
-
-    @staticmethod
-    def Subscribe(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.unary_stream(
-            request,
-            target,
-            '/altastata.v1.EventsService/Subscribe',
-            altastata_dot_v1_dot_events__pb2.SubscribeRequest.SerializeToString,
-            altastata_dot_v1_dot_events__pb2.EventMessage.FromString,
             options,
             channel_credentials,
             insecure,

--- a/proto/altastata/v1/events.proto
+++ b/proto/altastata/v1/events.proto
@@ -13,21 +13,16 @@ import "google/protobuf/timestamp.proto";
 //
 // See altastata-grpc/SESSION_AND_EVENTS_DESIGN.md §7 for the full model.
 //
-// Two RPCs live in this file:
+// Watch is the only event RPC. Each session (each browser tab / each
+// AuthService.Login) opens exactly one Watch stream after Login. The server
+// delivers a typed Event stream with monotonic per-userName sequence
+// numbers, supports since_sequence-based replay from the in-memory ring
+// buffer, and emits EventGap when the requested cursor is older than the
+// buffer.
 //
-//   Watch     — NEW.  Per-session server-streaming RPC backed by EventBus.
-//               Each session (each browser tab / each AuthService.Login) opens
-//               exactly one Watch stream after Login. The server delivers a
-//               typed Event stream with monotonic per-userName sequence
-//               numbers, supports since_sequence-based replay from the
-//               in-memory ring buffer, and emits EventGap when the requested
-//               cursor is older than the buffer.
-//
-//   Subscribe — DEPRECATED. The pre-EventBus path that registers a listener
-//               directly on AltaStataFileSystem and forwards untyped
-//               (eventName, data) tuples. Kept for backwards compatibility
-//               with the existing frontend; will be removed together with
-//               EventMessage / SubscribeRequest in PR-6 of the design doc.
+// The pre-EventBus untyped Subscribe RPC was removed once both first-party
+// clients (Console UI and altastata-python-package) had switched to Watch;
+// see SESSION_AND_EVENTS_DESIGN.md §12 for the migration history.
 // =============================================================================
 
 service EventsService {
@@ -36,9 +31,6 @@ service EventsService {
   // resolved server-side from the session token; clients cannot watch
   // events for another user.
   rpc Watch(WatchRequest) returns (stream Event);
-
-  // DEPRECATED: untyped pre-EventBus listener path. Use Watch instead.
-  rpc Subscribe(SubscribeRequest) returns (stream EventMessage);
 }
 
 // ---------- New typed event surface -----------------------------------------
@@ -115,15 +107,4 @@ message SessionRevokedEvent {
 // then trust live delivery from this point on.
 message EventGapEvent {
   uint64 server_oldest_sequence = 1;
-}
-
-// ---------- Legacy untyped Subscribe path (DEPRECATED) ----------------------
-
-message SubscribeRequest {}
-
-// DEPRECATED: only emitted by the legacy Subscribe RPC. New event payloads
-// must go through Event.payload, not here.
-message EventMessage {
-  string event_name = 1;
-  string data       = 2;
 }

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='altastata',
-    version='0.1.35',
+    version='0.1.36',
     author='Serge Vilvovsky',
     author_email='serge.vilvovsky@altastata.com',
     description='A Python package for Altastata data processing and machine learning integration',

--- a/tests/js-grpc-ui/app.js
+++ b/tests/js-grpc-ui/app.js
@@ -95,9 +95,6 @@ wV5BUmp5CEmbeB4r/+BlFttRZBLBXT1sq80YyQIVLumq0Livao9mOg==
     message RevokeByQueryRequest { string cloud_path_prefix = 1; bool including_subdirectories = 2; string time_interval_start = 3; string time_interval_end = 4; repeated string readers = 5; }
     message ShareResult { repeated FileStatus statuses = 1; }
     message RevokeResult { repeated FileStatus statuses = 1; }
-
-    message SubscribeRequest {}
-    message EventMessage { string event_name = 1; string data = 2; }
   `;
 
   const root = protobuf.parse(protoDef).root;
@@ -107,7 +104,6 @@ wV5BUmp5CEmbeB4r/+BlFttRZBLBXT1sq80YyQIVLumq0Livao9mOg==
   const outputEl = document.getElementById("output");
   const logsOutputEl = document.getElementById("logsOutput");
   const usersBody = document.getElementById("usersBody");
-  const eventsOutput = document.getElementById("eventsOutput");
 
   const userNameInput = document.getElementById("userNameInput");
   const userPasswordInput = document.getElementById("userPasswordInput");
@@ -132,7 +128,6 @@ wV5BUmp5CEmbeB4r/+BlFttRZBLBXT1sq80YyQIVLumq0Livao9mOg==
   attrNamesInput.value = "size,readers";
 
   let selectedFile = null;
-  let subscribeController = null;
   let authBootstrapDone = false;
   let authBootstrapInFlight = null;
 
@@ -152,19 +147,6 @@ wV5BUmp5CEmbeB4r/+BlFttRZBLBXT1sq80YyQIVLumq0Livao9mOg==
     }
     if (logsOutputEl) logsOutputEl.textContent += `\n${line}`;
     console.log(line);
-  }
-
-  function appendEvent(text) {
-    if (!eventsOutput) return;
-    const current = eventsOutput.textContent || "";
-    if (current === "No events yet." || current === "Subscribed. Waiting for events...") {
-      eventsOutput.textContent = text;
-    } else {
-      eventsOutput.textContent += `\n${text}`;
-    }
-    eventsOutput.scrollTop = eventsOutput.scrollHeight;
-    log("Event received", text);
-    setStatus(`Event: ${text}`);
   }
 
   function parseMyUserFromProperties(text) {
@@ -698,31 +680,6 @@ wV5BUmp5CEmbeB4r/+BlFttRZBLBXT1sq80YyQIVLumq0Livao9mOg==
       readers: asList(readersInput.value),
     }, "RevokeResult", true)
   ));
-
-  document.getElementById("subscribeBtn").addEventListener("click", () => run("Subscribe", async () => {
-    if (subscribeController) throw new Error("Already subscribed");
-    eventsOutput.textContent = "Subscribed. Waiting for events...";
-    subscribeController = new AbortController();
-    try {
-      await grpcServerStream("altastata.v1.EventsService/Subscribe", "SubscribeRequest", {}, "EventMessage", (msg) => {
-        const eventName = msg.event_name || msg.eventName || "event";
-        const data = msg.data || "";
-        appendEvent(`${eventName}: ${data}`);
-      }, true, subscribeController.signal);
-    } finally {
-      subscribeController = null;
-    }
-    return "Subscription ended";
-  }));
-
-  document.getElementById("stopSubscribeBtn").addEventListener("click", () => {
-    if (subscribeController) {
-      subscribeController.abort();
-      subscribeController = null;
-      setStatus("Subscribe stopped");
-      log("Subscribe stopped by user");
-    }
-  });
 
   const clearLogsBtn = document.getElementById("clearLogsBtn");
   if (clearLogsBtn) {

--- a/tests/js-grpc-ui/index.html
+++ b/tests/js-grpc-ui/index.html
@@ -184,17 +184,11 @@
     </div>
   </div>
 
-  <h2>EventsService (Live stream)</h2>
-  <div class="grid">
-    <div class="card">
-      <p class="hint">Start stream, perform file operations, observe events below.</p>
-      <div class="buttons">
-        <button id="subscribeBtn">Subscribe</button>
-        <button id="stopSubscribeBtn">Stop subscribe</button>
-      </div>
-      <pre id="eventsOutput">No events yet.</pre>
-    </div>
-  </div>
+  <!--
+    EventsService.Watch is exercised via the production Console UI; this
+    dev sandbox intentionally does not wire a button for it. See
+    altastata-grpc/SESSION_AND_EVENTS_DESIGN.md §7.
+  -->
 
   <script src="./protobuf.min.js"></script>
   <script src="./app.js"></script>


### PR DESCRIPTION
## Summary

- Migrate gRPC event delivery from the legacy untyped `EventsService.Subscribe` path to the typed `Watch` RPC. Public Python API stays the same.
- `setup.py`: 0.1.35 -> 0.1.36 (internal change; API-compatible).
- `tests/js-grpc-ui` dev sandbox: Subscribe button removed (live-stream is exercised via the production Console UI).

## How

A 6-line `_legacy_pair` helper translates `FileSharedEvent` / `FileUnsharedEvent` back to the `("SHARE"|"DELETE", path)` pair that `AltaStataEventListener` / Py4J listeners have always delivered, so existing user callbacks keep working unchanged. Other typed Watch payloads (`SessionRevokedEvent`, `EventGapEvent`) had no analogue on this surface and are skipped, matching prior behavior.

No reconnect-on-overflow loop on this surface — the old Subscribe worker also exited silently on stream error, and the per-session ring buffer (256 events) on the gateway is sized for human-pace SHARE/DELETE traffic. Anyone who needs replay can call `Watch(WatchRequest(since_sequence=N))` directly.

## Pairs with

- mycloud PR #187: removes `EventsService.Subscribe` from the gateway entirely (proto-breaking, bumps altastata-grpc 1.1.0 -> 1.2.0). This Python PR ships the new uber-jar inside the wheel, so the two move together.
- altastata-console (separate docs-only PR): drops legacy Subscribe references from `README.md`, `docs/architecture.md`, and the protobuf-snippet comment in `frontend/src/api/altastata.ts`.

## Test plan

- [x] `python -m unittest tests/test_grpc_client.py` -> 13/13 OK.
- [x] End-to-end smoke (two users in one Python process, Alice creates + shares with Bob, Bob's `add_event_listener` callback fires) against the rebuilt 1.2.0 uber-jar -> `SUCCESS: Bob received 1 SHARE event(s)`. Logout closes the Watch stream cleanly.
