### PR TITLE
fix(grpc): tolerate ALREADY_EXISTS during bootstrap; bump to 0.1.37

### DIFF
--- a/altastata/grpc_client.py
+++ b/altastata/grpc_client.py
@@ -694,14 +694,31 @@ def _bootstrap_and_login(
     channel = AltaStataGrpcClient._create_channel(endpoint)
     try:
         users = users_pb2_grpc.UsersServiceStub(channel)
-        users.SetUserProperties(users_pb2.SetUserPropertiesRequest(
-            user_name=user_name,
-            user_properties=user_properties,
-        ))
-        users.SetPrivateKey(users_pb2.SetPrivateKeyRequest(
-            user_name=user_name,
-            private_key_encrypted=private_key_encrypted,
-        ))
+        # The gateway returns ALREADY_EXISTS for SetUserProperties /
+        # SetPrivateKey when this userName already has a live
+        # AltaStataFileSystem (another browser tab / Python client of the
+        # same user is already logged in). The right reaction is to skip
+        # straight to AuthService.Login — the whole point of #186 was to
+        # stop a second client from re-installing properties / private
+        # key over a running session. See SESSION_AND_EVENTS_DESIGN.md
+        # §8.1.
+        try:
+            users.SetUserProperties(users_pb2.SetUserPropertiesRequest(
+                user_name=user_name,
+                user_properties=user_properties,
+            ))
+        except grpc.RpcError as exc:
+            if exc.code() != grpc.StatusCode.ALREADY_EXISTS:
+                raise
+        try:
+            users.SetPrivateKey(users_pb2.SetPrivateKeyRequest(
+                user_name=user_name,
+                private_key_encrypted=private_key_encrypted,
+            ))
+        except grpc.RpcError as exc:
+            if exc.code() != grpc.StatusCode.ALREADY_EXISTS:
+                raise
+
         auth = auth_pb2_grpc.AuthServiceStub(channel)
         resp = auth.Login(auth_pb2.LoginRequest(
             user_name=user_name,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='altastata',
-    version='0.1.36',
+    version='0.1.37',
     author='Serge Vilvovsky',
     author_email='serge.vilvovsky@altastata.com',
     description='A Python package for Altastata data processing and machine learning integration',


### PR DESCRIPTION
## Summary

Regression in the typical multi-client dev flow (Console UI tab open + Python in Jupyter) — the Python bootstrap helper crashes on `ALREADY_EXISTS` instead of falling through to `AuthService.Login`.

## Repro

1. Start the gateway (or `jupyter-datascience-arm64:test`) with `ENABLE_ALTASTATA_CONSOLE_UI=1`.
2. Open the Console UI tab and log in as `bob123` — backend boots a live `AltaStataFileSystem` for that user.
3. In a Jupyter notebook (same JVM), run:
   ```python
   AltaStataFunctions.from_credentials(user_properties, private_key, transport="grpc", password="123")
   ```
4. Crash with `_InactiveRpcError ALREADY_EXISTS: User is already bootstrapped; use AuthService.Login` raised from `users.SetUserProperties`. `Login` is never attempted.

## Root cause

The bootstrap RPC tightening from mycloud #186 makes `SetUserProperties` / `SetPrivateKey` return `ALREADY_EXISTS` once a userName already has a live fs — by design (anti-impersonation). The Python helper `_bootstrap_and_login`, however, still calls those two RPCs unconditionally before `AuthService.Login`, so any second client of the same user blows up before reaching Login.

This is documented design intent in `SESSION_AND_EVENTS_DESIGN.md` §8.1: "Make `SetUserProperties` / `SetPrivateKey` refuse with `ALREADY_EXISTS` when the user is fully bootstrapped." Backend behavior is correct; the Python client wasn't reading the contract.

## Fix

Catch `grpc.StatusCode.ALREADY_EXISTS` on each of the two bootstrap RPCs and fall through to `Login`. Any other status (INTERNAL / INVALID_ARGUMENT / UNAUTHENTICATED) still propagates. With this in place the second client just logs in to the existing live fs.

## Versioning

Bumps `altastata` 0.1.36 -> 0.1.37 (one-liner regression fix; no API change).

## Test plan

- [x] `python -m unittest tests/test_grpc_client.py` -> 13/13 OK
- [x] Live verification inside `altastata/jupyter-datascience-arm64:test` container with Console UI tab already logged in as `bob123`:
  - Before fix: `ALREADY_EXISTS` on `SetUserProperties`.
  - After hot-patching the updated `grpc_client.py` into the container and restarting the kernel: `from_credentials(..., transport='grpc', password='123')` succeeds and returns a working client.
