### PR TITLE
chore(docker): set ALTASTATA_GRPC_TLS=disabled in all bundled images

### DIFF
--- a/containers/jupyter/Dockerfile.amd64
+++ b/containers/jupyter/Dockerfile.amd64
@@ -87,6 +87,15 @@ ENV JUPYTER_CONFIG_DIR=/home/jovyan/.jupyter
 # altastata-grpc-server safe default is loopback; override here so Docker
 # port forwarding reaches it. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
+# Phase A would auto-enable HTTPS on this 0.0.0.0 bind, but inside a
+# Docker port-mapping (-p 127.0.0.1:9877:9877) the gateway is only
+# reachable via host loopback, so the threat model is the same as a
+# plain loopback bind. Self-signed HTTPS here also breaks Console UI
+# streaming gRPC-Web subresources in Chromium ("Failed to fetch" after
+# the user accepts the cert on the main page). Keep plain HTTP and let
+# operators stand up a TLS-terminating proxy when remote network
+# reachability is actually required. See TLS_DESIGN.md §10A.
+ENV ALTASTATA_GRPC_TLS=disabled
 
 # Optional Console UI on :9877. Off by default; set ENABLE_ALTASTATA_CONSOLE_UI=1
 # to auto-start altastata-grpc-server alongside Jupyter Lab.

--- a/containers/jupyter/Dockerfile.arm64
+++ b/containers/jupyter/Dockerfile.arm64
@@ -65,6 +65,15 @@ ENV LC_ALL=en_US.UTF-8
 # altastata-grpc-server safe default is loopback; override here so Docker
 # port forwarding reaches it. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
+# Phase A would auto-enable HTTPS on this 0.0.0.0 bind, but inside a
+# Docker port-mapping (-p 127.0.0.1:9877:9877) the gateway is only
+# reachable via host loopback, so the threat model is the same as a
+# plain loopback bind. Self-signed HTTPS here also breaks Console UI
+# streaming gRPC-Web subresources in Chromium ("Failed to fetch" after
+# the user accepts the cert on the main page). Keep plain HTTP and let
+# operators stand up a TLS-terminating proxy when remote network
+# reachability is actually required. See TLS_DESIGN.md §10A.
+ENV ALTASTATA_GRPC_TLS=disabled
 
 # Optional Console UI on :9877. Off by default; set ENABLE_ALTASTATA_CONSOLE_UI=1
 # to auto-start altastata-grpc-server alongside Jupyter Lab.

--- a/containers/jupyter/Dockerfile.s390x
+++ b/containers/jupyter/Dockerfile.s390x
@@ -114,6 +114,15 @@ ENV LC_ALL=en_US.UTF-8
 # altastata-grpc-server safe default is loopback; override here so Docker
 # port forwarding reaches it. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
+# Phase A would auto-enable HTTPS on this 0.0.0.0 bind, but inside a
+# Docker port-mapping (-p 127.0.0.1:9877:9877) the gateway is only
+# reachable via host loopback, so the threat model is the same as a
+# plain loopback bind. Self-signed HTTPS here also breaks Console UI
+# streaming gRPC-Web subresources in Chromium ("Failed to fetch" after
+# the user accepts the cert on the main page). Keep plain HTTP and let
+# operators stand up a TLS-terminating proxy when remote network
+# reachability is actually required. See TLS_DESIGN.md §10A.
+ENV ALTASTATA_GRPC_TLS=disabled
 
 # Optional Console UI on :9877. Off by default; set ENABLE_ALTASTATA_CONSOLE_UI=1
 # to auto-start altastata-grpc-server alongside Jupyter Lab.

--- a/containers/rag-example/Dockerfile.open_llm_mac
+++ b/containers/rag-example/Dockerfile.open_llm_mac
@@ -52,6 +52,12 @@ ENV LLM_PROVIDER=transformers
 # Optional Console UI on :9877; off by default (set ENABLE_ALTASTATA_CONSOLE_UI=1).
 # Host-side must use `-p 127.0.0.1:9877:9877`. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
+# Phase A would auto-enable HTTPS on this 0.0.0.0 bind, but inside a
+# Docker port-mapping the gateway is only reachable via host loopback —
+# same threat model as a plain loopback bind. Self-signed HTTPS here
+# also breaks Console UI streaming gRPC-Web subresources in Chromium.
+# See TLS_DESIGN.md §10A.
+ENV ALTASTATA_GRPC_TLS=disabled
 
 VOLUME /app/open_llm/local_index
 EXPOSE 8000 9877

--- a/containers/rag-example/Dockerfile.open_llm_s390x
+++ b/containers/rag-example/Dockerfile.open_llm_s390x
@@ -161,6 +161,12 @@ ENV LLAMA_CPP_MODEL_DIR=/models
 # Optional Console UI on :9877; off by default (set ENABLE_ALTASTATA_CONSOLE_UI=1).
 # Host-side must use `-p 127.0.0.1:9877:9877`. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
+# Phase A would auto-enable HTTPS on this 0.0.0.0 bind, but inside a
+# Docker port-mapping the gateway is only reachable via host loopback —
+# same threat model as a plain loopback bind. Self-signed HTTPS here
+# also breaks Console UI streaming gRPC-Web subresources in Chromium.
+# See TLS_DESIGN.md §10A.
+ENV ALTASTATA_GRPC_TLS=disabled
 
 VOLUME /app/open_llm/local_index
 VOLUME /models

--- a/examples/rag-example/open_llm/Dockerfile
+++ b/examples/rag-example/open_llm/Dockerfile
@@ -42,6 +42,12 @@ ENV LOCAL_INDEX_PATH=/app/open_llm/local_index
 # 0.0.0.0 lets Docker's port forwarder reach the gateway; host-side mapping
 # bounds exposure. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
+# Phase A would auto-enable HTTPS on this 0.0.0.0 bind, but inside a
+# Docker port-mapping the gateway is only reachable via host loopback —
+# same threat model as a plain loopback bind. Self-signed HTTPS here
+# also breaks Console UI streaming gRPC-Web subresources in Chromium.
+# See TLS_DESIGN.md §10A.
+ENV ALTASTATA_GRPC_TLS=disabled
 EXPOSE 8000 9877
 
 ENTRYPOINT ["/app/open_llm/docker-entrypoint.sh"]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='altastata',
-    version='0.1.38',
+    version='0.1.39',
     author='Serge Vilvovsky',
     author_email='serge.vilvovsky@altastata.com',
     description='A Python package for Altastata data processing and machine learning integration',


### PR DESCRIPTION
## Summary

Companion to **[mycloud PR #192](https://github.com/SergeVil/mycloud/pull/192)** adding the `ALTASTATA_GRPC_TLS={auto,disabled}` knob to Phase A.

Sets `ENV ALTASTATA_GRPC_TLS=disabled` in all 6 bundled Dockerfiles so the gateway inside the container keeps speaking plain HTTP, restoring the pre-Phase-A bundled experience:

- `containers/jupyter/Dockerfile.{amd64,arm64,s390x}`
- `containers/rag-example/Dockerfile.open_llm_{mac,s390x}`
- `examples/rag-example/open_llm/Dockerfile`

Also bumps `altastata` 0.1.38 → 0.1.39 so the next wheel ships the rebuilt `altastata-grpc-1.2.0-uber.jar` that contains the new `tls-mode` logic.

## Why HTTP for bundled Docker

The container has to bind `0.0.0.0` (Docker's NAT forwards host port mapping `127.0.0.1:9877:9877` into the container's external interface, not its loopback). Phase A's "non-loopback ⇒ HTTPS auto via tlsSelfSigned()" rule sees `0.0.0.0` and turns on TLS — but from the host's perspective the gateway is only reachable via host loopback. Worse, the ephemeral self-signed cert it generates breaks Console UI streaming gRPC-Web subresources in Chromium: even after the user clicks "Advanced → Proceed" on the main page, `EventsService.Watch` and other in-bundle `fetch()` calls fail with `TypeError: Failed to fetch`. The cert exception applies only to the top frame.

`ALTASTATA_GRPC_TLS=disabled` is the explicit operator declaration "this deployment is fronted by something else (Docker NAT into host loopback, in our case) — gateway should serve plain HTTP". Standalone non-Docker deployments where the operator picks a real network bind keep the Phase A auto-HTTPS path.

## Test plan

- [x] mycloud unit tests pass (16 of 16, including 4 new + 2 updated TLS tests).
- [ ] Manual: build `jupyter-datascience-arm64:latest` from this branch, run with `-p 127.0.0.1:9877:9877 -p 8888:8888 -e ENABLE_ALTASTATA_CONSOLE_UI=1`, open `http://127.0.0.1:9877/` in any browser, confirm Console UI loads and `EventsService.Watch` does not log `Failed to fetch`.
- [ ] Manual: same image + same env without `-p 127.0.0.1:9877:9877` (no port mapping), confirm Jupyter on `:8888` works.
- [ ] Manual: standalone (non-Docker) `pip install altastata-0.1.39 && altastata-grpc-server` with `ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0` (no `ALTASTATA_GRPC_TLS` override) → still auto-enables HTTPS (Phase A behaviour preserved for the non-bundled case).
