### PR TITLE
chore(docker): drop ALTASTATA_GRPC_TLS=disabled, bump 0.1.39 -> 0.1.40

### DIFF
--- a/containers/jupyter/Dockerfile.amd64
+++ b/containers/jupyter/Dockerfile.amd64
@@ -87,15 +87,6 @@ ENV JUPYTER_CONFIG_DIR=/home/jovyan/.jupyter
 # altastata-grpc-server safe default is loopback; override here so Docker
 # port forwarding reaches it. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
-# Phase A would auto-enable HTTPS on this 0.0.0.0 bind, but inside a
-# Docker port-mapping (-p 127.0.0.1:9877:9877) the gateway is only
-# reachable via host loopback, so the threat model is the same as a
-# plain loopback bind. Self-signed HTTPS here also breaks Console UI
-# streaming gRPC-Web subresources in Chromium ("Failed to fetch" after
-# the user accepts the cert on the main page). Keep plain HTTP and let
-# operators stand up a TLS-terminating proxy when remote network
-# reachability is actually required. See TLS_DESIGN.md §10A.
-ENV ALTASTATA_GRPC_TLS=disabled
 
 # Optional Console UI on :9877. Off by default; set ENABLE_ALTASTATA_CONSOLE_UI=1
 # to auto-start altastata-grpc-server alongside Jupyter Lab.

--- a/containers/jupyter/Dockerfile.arm64
+++ b/containers/jupyter/Dockerfile.arm64
@@ -65,15 +65,6 @@ ENV LC_ALL=en_US.UTF-8
 # altastata-grpc-server safe default is loopback; override here so Docker
 # port forwarding reaches it. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
-# Phase A would auto-enable HTTPS on this 0.0.0.0 bind, but inside a
-# Docker port-mapping (-p 127.0.0.1:9877:9877) the gateway is only
-# reachable via host loopback, so the threat model is the same as a
-# plain loopback bind. Self-signed HTTPS here also breaks Console UI
-# streaming gRPC-Web subresources in Chromium ("Failed to fetch" after
-# the user accepts the cert on the main page). Keep plain HTTP and let
-# operators stand up a TLS-terminating proxy when remote network
-# reachability is actually required. See TLS_DESIGN.md §10A.
-ENV ALTASTATA_GRPC_TLS=disabled
 
 # Optional Console UI on :9877. Off by default; set ENABLE_ALTASTATA_CONSOLE_UI=1
 # to auto-start altastata-grpc-server alongside Jupyter Lab.

--- a/containers/jupyter/Dockerfile.s390x
+++ b/containers/jupyter/Dockerfile.s390x
@@ -114,15 +114,6 @@ ENV LC_ALL=en_US.UTF-8
 # altastata-grpc-server safe default is loopback; override here so Docker
 # port forwarding reaches it. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
-# Phase A would auto-enable HTTPS on this 0.0.0.0 bind, but inside a
-# Docker port-mapping (-p 127.0.0.1:9877:9877) the gateway is only
-# reachable via host loopback, so the threat model is the same as a
-# plain loopback bind. Self-signed HTTPS here also breaks Console UI
-# streaming gRPC-Web subresources in Chromium ("Failed to fetch" after
-# the user accepts the cert on the main page). Keep plain HTTP and let
-# operators stand up a TLS-terminating proxy when remote network
-# reachability is actually required. See TLS_DESIGN.md §10A.
-ENV ALTASTATA_GRPC_TLS=disabled
 
 # Optional Console UI on :9877. Off by default; set ENABLE_ALTASTATA_CONSOLE_UI=1
 # to auto-start altastata-grpc-server alongside Jupyter Lab.

--- a/containers/rag-example/Dockerfile.open_llm_mac
+++ b/containers/rag-example/Dockerfile.open_llm_mac
@@ -52,12 +52,6 @@ ENV LLM_PROVIDER=transformers
 # Optional Console UI on :9877; off by default (set ENABLE_ALTASTATA_CONSOLE_UI=1).
 # Host-side must use `-p 127.0.0.1:9877:9877`. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
-# Phase A would auto-enable HTTPS on this 0.0.0.0 bind, but inside a
-# Docker port-mapping the gateway is only reachable via host loopback —
-# same threat model as a plain loopback bind. Self-signed HTTPS here
-# also breaks Console UI streaming gRPC-Web subresources in Chromium.
-# See TLS_DESIGN.md §10A.
-ENV ALTASTATA_GRPC_TLS=disabled
 
 VOLUME /app/open_llm/local_index
 EXPOSE 8000 9877

--- a/containers/rag-example/Dockerfile.open_llm_s390x
+++ b/containers/rag-example/Dockerfile.open_llm_s390x
@@ -161,12 +161,6 @@ ENV LLAMA_CPP_MODEL_DIR=/models
 # Optional Console UI on :9877; off by default (set ENABLE_ALTASTATA_CONSOLE_UI=1).
 # Host-side must use `-p 127.0.0.1:9877:9877`. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
-# Phase A would auto-enable HTTPS on this 0.0.0.0 bind, but inside a
-# Docker port-mapping the gateway is only reachable via host loopback —
-# same threat model as a plain loopback bind. Self-signed HTTPS here
-# also breaks Console UI streaming gRPC-Web subresources in Chromium.
-# See TLS_DESIGN.md §10A.
-ENV ALTASTATA_GRPC_TLS=disabled
 
 VOLUME /app/open_llm/local_index
 VOLUME /models

--- a/examples/rag-example/open_llm/Dockerfile
+++ b/examples/rag-example/open_llm/Dockerfile
@@ -42,12 +42,6 @@ ENV LOCAL_INDEX_PATH=/app/open_llm/local_index
 # 0.0.0.0 lets Docker's port forwarder reach the gateway; host-side mapping
 # bounds exposure. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
-# Phase A would auto-enable HTTPS on this 0.0.0.0 bind, but inside a
-# Docker port-mapping the gateway is only reachable via host loopback —
-# same threat model as a plain loopback bind. Self-signed HTTPS here
-# also breaks Console UI streaming gRPC-Web subresources in Chromium.
-# See TLS_DESIGN.md §10A.
-ENV ALTASTATA_GRPC_TLS=disabled
 EXPOSE 8000 9877
 
 ENTRYPOINT ["/app/open_llm/docker-entrypoint.sh"]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='altastata',
-    version='0.1.39',
+    version='0.1.40',
     author='Serge Vilvovsky',
     author_email='serge.vilvovsky@altastata.com',
     description='A Python package for Altastata data processing and machine learning integration',


### PR DESCRIPTION
## TL;DR

Drops `ENV ALTASTATA_GRPC_TLS=disabled` from all bundled Dockerfiles and bumps the package `0.1.39 → 0.1.40`. The knob no longer exists in the upstream gateway.

## Context

`ENV ALTASTATA_GRPC_TLS=disabled` was added in PR #93 as a workaround for [mycloud PR #193](https://github.com/SergeVil/mycloud/pull/193) — the `tls-mode={auto,disabled}` knob — so bundled Docker images would force the gateway into plain HTTP and avoid Phase A's auto-HTTPS self-signed cert.

We then reverted Phase A entirely in [mycloud PR #194](https://github.com/SergeVil/mycloud/pull/194) once we confirmed Chrome hard-blocks self-signed POST subresources (gRPC-Web POST → `TypeError: Failed to fetch`) regardless of the cert SAN. With Phase A gone, the gateway always serves plain HTTP, so the `ALTASTATA_GRPC_TLS` ENV is meaningless and would be misleading to leave behind.

## What changed

- Remove `ENV ALTASTATA_GRPC_TLS=disabled` and the surrounding multi-line comment from:
  - `containers/jupyter/Dockerfile.{amd64,arm64,s390x}`
  - `containers/rag-example/Dockerfile.open_llm_{mac,s390x}`
  - `examples/rag-example/open_llm/Dockerfile`
- `ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0` lines and their comments stay (Docker NAT still needs all-interfaces inside the container; host-side mapping `127.0.0.1:9877:9877` remains the safe default).
- Refresh `altastata/lib/altastata-grpc-1.2.0-uber.jar` to the post-revert build (HTTP-only).
- `setup.py`: `0.1.39 → 0.1.40`.

## Test plan

- [x] Built jupyter-datascience ARM64 image with the new jar.
- [x] Container starts, listens on `http://127.0.0.1:9877/`.
- [x] Console UI in Chrome works end-to-end: login + listDir + SHARE/DELETE event streaming, no `Failed to fetch`.
- [ ] Smoke test the AMD64 build before publishing `0.1.40` to PyPI / pushing the new image to GHCR.
