### PR TITLE
fix(grpc-client): skip SetPrivateKey for HPCS/HSM accounts (bump 0.1.40)

### DIFF
--- a/altastata/grpc_client.py
+++ b/altastata/grpc_client.py
@@ -725,6 +725,12 @@ def _bootstrap_and_login(
     auth-bypassed on the server because the user has no session yet at this
     point. ``Login`` is the first authenticated call: a wrong password is
     rejected here without corrupting any other live session for the same user.
+
+    HPCS / HSM-backed accounts pass ``private_key_encrypted=""`` because the
+    private key material lives in the HSM rather than as a local PEM. In that
+    case ``SetPrivateKey`` is skipped entirely — the gateway sources the key
+    material server-side from ``user_properties`` (e.g. ``hpcs-priv-key-blob-path``
+    + ``hpcs-yaml-path``) and the EP11 client.
     """
     try:
         from .v1 import auth_pb2, auth_pb2_grpc
@@ -753,14 +759,19 @@ def _bootstrap_and_login(
         except grpc.RpcError as exc:
             if exc.code() != grpc.StatusCode.ALREADY_EXISTS:
                 raise
-        try:
-            users.SetPrivateKey(users_pb2.SetPrivateKeyRequest(
-                user_name=user_name,
-                private_key_encrypted=private_key_encrypted,
-            ))
-        except grpc.RpcError as exc:
-            if exc.code() != grpc.StatusCode.ALREADY_EXISTS:
-                raise
+        # HPCS / HSM-backed accounts have no PEM to send; the server's
+        # SetPrivateKey validator rejects an empty private_key_encrypted with
+        # INVALID_ARGUMENT, so skip the call entirely in that case. The
+        # gateway derives the key material from user_properties on first use.
+        if private_key_encrypted:
+            try:
+                users.SetPrivateKey(users_pb2.SetPrivateKeyRequest(
+                    user_name=user_name,
+                    private_key_encrypted=private_key_encrypted,
+                ))
+            except grpc.RpcError as exc:
+                if exc.code() != grpc.StatusCode.ALREADY_EXISTS:
+                    raise
 
         auth = auth_pb2_grpc.AuthServiceStub(channel)
         resp = auth.Login(auth_pb2.LoginRequest(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='altastata',
-    version='0.1.39',
+    version='0.1.40',
     author='Serge Vilvovsky',
     author_email='serge.vilvovsky@altastata.com',
     description='A Python package for Altastata data processing and machine learning integration',

--- a/tests/test_grpc_client.py
+++ b/tests/test_grpc_client.py
@@ -189,6 +189,78 @@ class GrpcClientTests(unittest.TestCase):
         mock_start_server.assert_called_once()
         mock_bootstrap_and_login.assert_called_once()
 
+    @patch("altastata.grpc_client.AltaStataGrpcClient._create_channel")
+    def test_bootstrap_skips_set_private_key_for_hpcs_account(self, mock_create_channel):
+        """HPCS / HSM-backed accounts pass private_key_encrypted="" because the
+        key lives in the HSM. The server's SetPrivateKey validator rejects an
+        empty PEM with INVALID_ARGUMENT, so the client must skip that RPC
+        entirely. SetUserProperties and Login must still run."""
+        users_stub_mock = MagicMock()
+        auth_stub_mock = MagicMock()
+        auth_stub_mock.Login.return_value = MagicMock(session_token="sess-hpcs-token")
+
+        sys.modules["altastata.v1.users_pb2_grpc"].UsersServiceStub = MagicMock(
+            return_value=users_stub_mock,
+        )
+        sys.modules["altastata.v1.auth_pb2_grpc"].AuthServiceStub = MagicMock(
+            return_value=auth_stub_mock,
+        )
+        sys.modules["altastata.v1.users_pb2"].SetUserPropertiesRequest = MagicMock()
+        sys.modules["altastata.v1.users_pb2"].SetPrivateKeyRequest = MagicMock()
+        sys.modules["altastata.v1.auth_pb2"].LoginRequest = MagicMock()
+
+        mock_create_channel.return_value = MagicMock()
+
+        from altastata.grpc_client import _bootstrap_and_login, GrpcEndpoint
+        token = _bootstrap_and_login(
+            endpoint=GrpcEndpoint(host="127.0.0.1", port=9877, secure=False),
+            user_name="serge678",
+            user_properties="myuser=serge678\nkey-protection=HPCS\n",
+            private_key_encrypted="",
+            password="",
+            client_hint="hpcs-test",
+        )
+
+        self.assertEqual("sess-hpcs-token", token)
+        users_stub_mock.SetUserProperties.assert_called_once()
+        users_stub_mock.SetPrivateKey.assert_not_called()
+        auth_stub_mock.Login.assert_called_once()
+
+    @patch("altastata.grpc_client.AltaStataGrpcClient._create_channel")
+    def test_bootstrap_calls_set_private_key_for_rsa_account(self, mock_create_channel):
+        """Regression guard: password-based / RSA accounts pass a real
+        encrypted PEM and SetPrivateKey must still be called for them."""
+        users_stub_mock = MagicMock()
+        auth_stub_mock = MagicMock()
+        auth_stub_mock.Login.return_value = MagicMock(session_token="sess-rsa-token")
+
+        sys.modules["altastata.v1.users_pb2_grpc"].UsersServiceStub = MagicMock(
+            return_value=users_stub_mock,
+        )
+        sys.modules["altastata.v1.auth_pb2_grpc"].AuthServiceStub = MagicMock(
+            return_value=auth_stub_mock,
+        )
+        sys.modules["altastata.v1.users_pb2"].SetUserPropertiesRequest = MagicMock()
+        sys.modules["altastata.v1.users_pb2"].SetPrivateKeyRequest = MagicMock()
+        sys.modules["altastata.v1.auth_pb2"].LoginRequest = MagicMock()
+
+        mock_create_channel.return_value = MagicMock()
+
+        from altastata.grpc_client import _bootstrap_and_login, GrpcEndpoint
+        token = _bootstrap_and_login(
+            endpoint=GrpcEndpoint(host="127.0.0.1", port=9877, secure=False),
+            user_name="bob123",
+            user_properties="myuser=bob123\n",
+            private_key_encrypted="-----BEGIN RSA PRIVATE KEY-----\n...\n",
+            password="123",
+            client_hint="rsa-test",
+        )
+
+        self.assertEqual("sess-rsa-token", token)
+        users_stub_mock.SetUserProperties.assert_called_once()
+        users_stub_mock.SetPrivateKey.assert_called_once()
+        auth_stub_mock.Login.assert_called_once()
+
     @patch("altastata.grpc_client.subprocess.Popen")
     @patch("altastata.grpc_client._find_bundled_grpc_uber_jar")
     @patch("altastata.grpc_client._build_bundled_grpc_classpath")


### PR DESCRIPTION
## Summary

HPCS / HSM-backed accounts call `AltaStataFunctions.from_credentials(user_properties, "", transport="grpc", password="")` — no PEM, no password (the key lives in the HSM). Py4J handles this fine, but the gRPC bootstrap was unconditionally calling `SetPrivateKey` with the empty PEM, which the server rejected with `INVALID_ARGUMENT: "user_name and private_key_encrypted cannot be empty"`.

- `_bootstrap_and_login` now skips `SetPrivateKey` entirely when `private_key_encrypted` is empty. The gateway derives the key material server-side from `user_properties` (`hpcs-priv-key-blob-path` / `hpcs-yaml-path`).
- RSA / password-based accounts: zero behaviour change (regression guard test added).
- Bumps `altastata` 0.1.39 → 0.1.40 so the next image build picks the fix up via `pip install altastata`.

Companion server-side relaxation ships in `mycloud/altastata-grpc` (drops the matching transport validators in `AuthGrpcService.login` + `GrpcUserRegistry.initializeAndSetPassword`); both fixes together restore parity with Py4J. Without the companion Java PR the empty-password `Login` leg still fails.

## Test plan

- [x] `pytest tests/test_grpc_client.py` — 15/15 pass, including the new `test_bootstrap_skips_set_private_key_for_hpcs_account` and `test_bootstrap_calls_set_private_key_for_rsa_account` regression guard.
- [x] End-to-end on s390x (LinuxONE, `163.66.89.80`): hot-swapped this `grpc_client.py` + the companion patched gRPC JAR into `altastata-jupyter-s390x-web` and reran the HPCS notebook cell. `Login` now succeeds; the downstream `FAILED_PRECONDITION: HPCS configuration errors ...` is the legitimate, actionable error from `altastata-core` when the HPCS files aren't mounted (same error Py4J surfaces).
- [ ] Once merged + wheel published: rebuild s390x Jupyter and RAG images (canonical artifact replaces the hot-swap).
