### PR TITLE
chore(release): bump Jupyter 2026e_latest / RAG 2026j_latest + Jupyter HPCS auto-mount

### DIFF
--- a/containers/jupyter/README-Docker.md
+++ b/containers/jupyter/README-Docker.md
@@ -31,8 +31,8 @@ The Docker image version is centrally managed in `version.sh`. To update the ver
 
 1. Edit `version.sh` and update the relevant variable:
    ```bash
-   JUPYTER_VERSION="2026d_latest"   # Bump on real Jupyter image changes
-   RAG_VERSION="2026i_latest"       # Bump on RAG image changes (zDNN variant is :${RAG_VERSION}_zdnn)
+   JUPYTER_VERSION="2026e_latest"   # Bump on real Jupyter image changes
+   RAG_VERSION="2026j_latest"       # Bump on RAG image changes (zDNN variant is :${RAG_VERSION}_zdnn)
    ```
 
 2. Run the update script to sync the version to all configuration files:
@@ -85,7 +85,7 @@ separately using `containers/jupyter/Dockerfile.s390x`.
 ### Usage (AMD64 + ARM64)
 
 ```bash
-# Pull image for your platform (version from version.sh, currently JUPYTER_VERSION=2026d_latest)
+# Pull image for your platform (version from version.sh, currently JUPYTER_VERSION=2026e_latest)
 source version.sh
 VERSION="${JUPYTER_VERSION}"
 

--- a/containers/jupyter/README-ICR-BUILD-AND-PUSH.md
+++ b/containers/jupyter/README-ICR-BUILD-AND-PUSH.md
@@ -13,8 +13,8 @@ then tagging and pushing the s390x image to IBM Container Registry (ICR).
 
 `version.sh` exposes two image tags (different release cadences):
 
-- `JUPYTER_VERSION` (currently `2026d_latest`) — used for `jupyter-datascience-{arm64,amd64,s390x}`.
-- `RAG_VERSION` (currently `2026i_latest`) — used for `rag-open-llm-s390x`. The `:${RAG_VERSION}_zdnn` variant is the research/zDNN-on build; the plain tag is the default CPU build.
+- `JUPYTER_VERSION` (currently `2026e_latest`) — used for `jupyter-datascience-{arm64,amd64,s390x}`.
+- `RAG_VERSION` (currently `2026j_latest`) — used for `rag-open-llm-s390x`. The `:${RAG_VERSION}_zdnn` variant is the research/zDNN-on build; the plain tag is the default CPU build.
 
 Source `version.sh` once and the rest of these examples just use `${JUPYTER_VERSION}` / `${RAG_VERSION}`.
 
@@ -106,7 +106,7 @@ docker buildx build --platform linux/s390x -f containers/rag-example/Dockerfile.
 
 ### Tag and push RAG s390x to ICR
 
-Uses **`RAG_VERSION`** from `version.sh` (currently **`2026i_latest`** — different from Jupyter’s **`JUPYTER_VERSION`** / `2026d_latest`).
+Uses **`RAG_VERSION`** from `version.sh` (currently **`2026j_latest`** — different from Jupyter’s **`JUPYTER_VERSION`** / `2026e_latest`).
 
 **Push from server** (image was built with `build-rag-s390x-on-server.sh`):
 ```bash

--- a/containers/linuxone/run-jupyter-and-rag-on-server-for-browser.sh
+++ b/containers/linuxone/run-jupyter-and-rag-on-server-for-browser.sh
@@ -60,13 +60,36 @@ echo ""
 
 ssh $SSH_OPTS "$SSH_HOST" "mkdir -p '$REMOTE_JUP_WORK' '$REMOTE_MODELS_DIR'" || true
 
+# Console UI (gRPC + SPA) defaults to enabled inside the Jupyter image but is
+# only reachable through the port we publish here. Bind 9877 the same way 8888
+# is bound; override with JUPYTER_CONSOLE_UI_HOST_PORT.
+JUPYTER_CONSOLE_UI_HOST_PORT="${JUPYTER_CONSOLE_UI_HOST_PORT:-9877}"
+
+# HPCS auto-mount for Jupyter: when the canonical HPCS files exist on the VM,
+# mount them at the paths the example notebooks reference. This matches what
+# the RAG block below already does. If you don't use HPCS the mounts are
+# simply skipped (no failure). The mount destinations match the
+# user_properties shipped in the example notebooks:
+#   hpcs-yaml-path=/etc/ep11client/grep11client.yaml
+#   hpcs-priv-key-blob-path=/home/jovyan/hpcs-privkey.blob
+JUP_HPCS_MOUNTS=""
+if ssh $SSH_OPTS "$SSH_HOST" "test -f '$REMOTE_GREP11_YAML'" 2>/dev/null; then
+  JUP_HPCS_MOUNTS="$JUP_HPCS_MOUNTS -v $REMOTE_GREP11_YAML:/etc/ep11client/grep11client.yaml:ro"
+fi
+if ssh $SSH_OPTS "$SSH_HOST" "test -f '$REMOTE_HPCS_BLOB'" 2>/dev/null; then
+  JUP_HPCS_MOUNTS="$JUP_HPCS_MOUNTS -v $REMOTE_HPCS_BLOB:/home/jovyan/hpcs-privkey.blob:ro"
+fi
+[ -n "$JUP_HPCS_MOUNTS" ] && echo "  HPCS mounts for Jupyter:$JUP_HPCS_MOUNTS"
+
 if [ "$RUN_JUP" = "1" ]; then
   echo "--- Starting Jupyter (detached)"
   ssh $SSH_OPTS "$SSH_HOST" "docker rm -f '$JUP_CTR' 2>/dev/null || true"
   ssh $SSH_OPTS "$SSH_HOST" "docker run -d --name '$JUP_CTR' \
     -p '${JUPYTER_HOST_PORT}:8888' \
+    -p '${JUPYTER_CONSOLE_UI_HOST_PORT}:9877' \
     -v '${REMOTE_JUP_WORK}:/home/jovyan/work' \
     -v '/root/.altastata:/opt/app-root/src/.altastata:rw' \
+    $JUP_HPCS_MOUNTS \
     '$JUP_IMG'"
 else
   echo "--- Skipping Jupyter (RUN_JUP=$RUN_JUP)"
@@ -109,7 +132,8 @@ fi
 echo ""
 echo "===== Browser ====="
 [ "$RUN_JUP" = "1" ] && {
-  echo "Jupyter Lab:  http://$PUBLIC_HOST:$JUPYTER_HOST_PORT/"
+  echo "Jupyter Lab:    http://$PUBLIC_HOST:$JUPYTER_HOST_PORT/"
+  echo "Console UI:     http://$PUBLIC_HOST:$JUPYTER_CONSOLE_UI_HOST_PORT/   (set gRPC base URL to the same host:port on first load)"
   echo "Get token:      ssh $SSH_OPTS $SSH_HOST \"docker exec '$JUP_CTR' jupyter server list\""
   echo "Logs:           ssh $SSH_OPTS $SSH_HOST \"docker logs -f '$JUP_CTR'\""
 }

--- a/version.sh
+++ b/version.sh
@@ -20,8 +20,8 @@
 # work. Separating the tags keeps each image's history truthful and avoids
 # end-user confusion ("did Jupyter change between 2026e and 2026g?" — no).
 
-JUPYTER_VERSION="2026d_latest"
-RAG_VERSION="2026i_latest"
+JUPYTER_VERSION="2026e_latest"
+RAG_VERSION="2026j_latest"
 
 # Resolve repo root from this script's location so callers can `source version.sh`
 # from any cwd. Falls back to the current dir if BASH_SOURCE isn't available.


### PR DESCRIPTION
## Summary

Bumps image tags to surface the HSM-backed gRPC bootstrap fix shipped in `altastata` 0.1.40 (PR #95) + the matching `mycloud/altastata-grpc` relaxation (#195). The next image rebuild replaces the `.class`-file hot-swap that has been propping up the running s390x container during today's testing with the canonical artifact built from the merged sources.

- `version.sh` — `JUPYTER_VERSION` `2026d_latest` → `2026e_latest` (applies to arm64 / amd64 / s390x), `RAG_VERSION` `2026i_latest` → `2026j_latest` (s390x).
- `containers/linuxone/run-jupyter-and-rag-on-server-for-browser.sh` — Jupyter block now publishes the Console UI port (default `9877`, overridable via `JUPYTER_CONSOLE_UI_HOST_PORT`) and **auto-mounts** the two canonical HPCS files when they exist on the VM:
  - `/etc/ep11client/grep11client.yaml`
  - `${REMOTE_HPCS_DIR}/hpcs-privkey.blob` → `/home/jovyan/hpcs-privkey.blob`

  Mirror of what the RAG block already does. Removes the manual `docker rm && docker run -v ...` step for HPCS notebooks. No-op for non-HPCS accounts (files just aren't present → mount lines are skipped).
- `containers/jupyter/README-ICR-BUILD-AND-PUSH.md`, `containers/jupyter/README-Docker.md` — refreshed the "currently" version references.

## Test plan

- [x] `source version.sh` resolves the new tags + `ALTASTATA_PYPI_VERSION=0.1.40`.
- [ ] arm64 build (Mac local): `docker build -f containers/jupyter/Dockerfile.arm64 ... -t altastata/jupyter-datascience-arm64:2026e_latest .` (in progress in parallel with this PR).
- [ ] s390x build on LinuxONE: `./containers/build-s390x-jupyter-and-rag-on-server.sh` (rsync + remote `build-jupyter-and-rag-on-linuxone.sh`, detached; in progress).
- [ ] End-to-end: stop the hot-patched container and `./containers/linuxone/run-jupyter-and-rag-on-server-for-browser.sh` → confirm Jupyter at `:8888`, Console UI at `:9877`, and the HPCS notebook cell works without manual mounts.
- [ ] ICR push deferred until Nicolas's new token arrives.
