### PR TITLE
fix(linuxone-run): start Console UI by default in Jupyter container

### DIFF
--- a/containers/linuxone/run-jupyter-and-rag-on-server-for-browser.sh
+++ b/containers/linuxone/run-jupyter-and-rag-on-server-for-browser.sh
@@ -87,6 +87,7 @@ if [ "$RUN_JUP" = "1" ]; then
   ssh $SSH_OPTS "$SSH_HOST" "docker run -d --name '$JUP_CTR' \
     -p '${JUPYTER_HOST_PORT}:8888' \
     -p '${JUPYTER_CONSOLE_UI_HOST_PORT}:9877' \
+    -e 'ENABLE_ALTASTATA_CONSOLE_UI=${ENABLE_ALTASTATA_CONSOLE_UI:-1}' \
     -v '${REMOTE_JUP_WORK}:/home/jovyan/work' \
     -v '/root/.altastata:/opt/app-root/src/.altastata:rw' \
     $JUP_HPCS_MOUNTS \


### PR DESCRIPTION
## Summary

- The s390x / arm64 / amd64 Jupyter `Dockerfile`s deliberately leave `ENABLE_ALTASTATA_CONSOLE_UI` **unset** (off-by-default per `altastata-console-entrypoint.sh`).
- Previously only `containers/jupyter/docker-compose.yml` defaulted it on (`${ENABLE_ALTASTATA_CONSOLE_UI:-1}`).
- `containers/linuxone/run-jupyter-and-rag-on-server-for-browser.sh` exposed `-p 9877:9877` but never set the env, so `altastata-grpc-server` never started — Console UI was unreachable until you `docker exec` started it manually (which I had to do today after deploying the new s390x images).

Now the run script also defaults to `1`, mirroring the docker-compose default and my local Mac arm64 invocation. Override with `ENABLE_ALTASTATA_CONSOLE_UI=0` when calling the script.

## Test plan

- [x] Verified on LinuxONE: with the manual `docker exec ... altastata-grpc-server` workaround the Console UI on `http://163.66.89.80:9877/` serves and successfully bootstraps the HPCS account end-to-end.
- [ ] Re-run the script on LinuxONE after merge and confirm `/tmp/altastata-grpc-server.log` appears inside the new container with no manual `docker exec` needed.
- [ ] Confirm `ENABLE_ALTASTATA_CONSOLE_UI=0 ./containers/linuxone/run-jupyter-and-rag-on-server-for-browser.sh` still leaves port 9877 quiet (override path).


Made with [Cursor](https://cursor.com)