### PR TITLE
feat(wheel): switch to altastata-services uber jar; route py4j through AccountRegistry

### DIFF
--- a/GRPC_VS_PY4J_BENCHMARK.md
+++ b/GRPC_VS_PY4J_BENCHMARK.md
@@ -11,21 +11,26 @@ This benchmark compares control-plane latency for equivalent calls:
 
 ```bash
 cd /Users/sergevilvovsky/eclipse-workspace/mcloud/mycloud
-./gradlew :altastata-grpc:run
+./gradlew :altastata-services:run
 ```
 
 ### 2) Initialize gateway user/session with account files
 
+The three bootstrap PUTs used to live on Micronaut port 9880; after the
+`altastata-services` consolidation they are served by Armeria on port 9877
+alongside the gRPC server (see
+`mycloud/ALTASTATA_SERVICES_UBER_DESIGN.md` §3.1).
+
 ```bash
-curl -sS -X PUT "http://127.0.0.1:9880/setUserProperties/bob123" \
+curl -sS -X PUT "http://127.0.0.1:9877/setUserProperties/bob123" \
   -H "Content-Type: text/plain" \
   --data-binary @"/Users/sergevilvovsky/.altastata/accounts/amazon.rsa.bob123/altastata-myorgrsa444-bob123.user.properties"
 
-curl -sS -X PUT "http://127.0.0.1:9880/setPrivateKey/bob123" \
+curl -sS -X PUT "http://127.0.0.1:9877/setPrivateKey/bob123" \
   -H "Content-Type: text/plain" \
   --data-binary @"/Users/sergevilvovsky/.altastata/accounts/amazon.rsa.bob123/private.key"
 
-curl -sS -X PUT "http://127.0.0.1:9880/setPassword/bob123" \
+curl -sS -X PUT "http://127.0.0.1:9877/setPassword/bob123" \
   -H "Content-Type: text/plain" \
   --data "123"
 ```

--- a/README-developer.md
+++ b/README-developer.md
@@ -9,7 +9,9 @@
 The wheel ships with two binary artifacts that this repo deliberately does
 not commit to git:
 
-- `altastata/lib/altastata-grpc-<ver>-uber.jar` (built from `mycloud/altastata-grpc`)
+- `altastata/lib/altastata-services-<ver>-uber.jar` (built from
+  `mycloud/altastata-services` — the unified Micronaut app that hosts gRPC,
+  the S3 gateway, and py4j under `com.altastata.services.AltaStataServicesApplication`)
 - `altastata/lib/altastata-console-static/` (built from `altastata-console/frontend`)
 
 Only `altastata/lib/py4j0.10.9.5.jar` is tracked in git, since it is a fixed
@@ -35,10 +37,13 @@ next to this repo. Override with `ALTASTATA_MYCLOUD_DIR` /
 
 If you prefer to drive each build yourself:
 
-1. Build the gRPC uber jar in `mycloud/altastata-grpc`:
+1. Build the unified services uber jar in `mycloud/altastata-services`:
    ```bash
-   (cd ../mycloud && ./gradlew :altastata-grpc:shadowJar)
-   cp ../mycloud/altastata-grpc/build/libs/altastata-grpc-*-uber.jar altastata/lib/
+   (cd ../mycloud && ./gradlew :altastata-services:shadowJar)
+   cp ../mycloud/altastata-services/build/libs/altastata-services-*-uber.jar altastata/lib/
+   # BouncyCastle is externalized as signed JCE jars referenced from the
+   # uber jar manifest Class-Path; co-locate them alongside the uber jar:
+   cp ../mycloud/altastata-services/build/libs/lib/bc*.jar altastata/lib/
    ```
 
 2. Build the Console SPA in `altastata-console/frontend`:

--- a/altastata/altastata_functions.py
+++ b/altastata/altastata_functions.py
@@ -147,7 +147,14 @@ class AltaStataFunctions(BaseGateway):
             callback_server_port=callback_server_port,
             transport="py4j",
         )
-        instance.altastata_file_system = instance.gateway.jvm.com.altastata.api.AltaStataFileSystem(account_dir_path)
+        # The AltaStataFileSystem constructor is package-private since the
+        # AccountRegistry refactor: direct `new AltaStataFileSystem(...)` over
+        # py4j now fails reflection. Route through the registry's static
+        # factory so the per-(prefix,user,accounttype) instance is shared
+        # JVM-wide with any co-hosted gRPC / S3 / examples.
+        instance.altastata_file_system = (
+            instance.gateway.jvm.com.altastata.api.AccountRegistry.getOrCreateFromDir(account_dir_path)
+        )
         return instance
 
     @classmethod
@@ -205,7 +212,13 @@ class AltaStataFunctions(BaseGateway):
             callback_server_port=callback_server_port,
             transport="py4j",
         )
-        instance.altastata_file_system = instance.gateway.jvm.com.altastata.api.AltaStataFileSystem(user_properties, private_key_encrypted)
+        # See note in from_account_dir: package-private constructor is no
+        # longer reachable via py4j reflection, so go through the registry.
+        instance.altastata_file_system = (
+            instance.gateway.jvm.com.altastata.api.AccountRegistry.getOrCreate(
+                user_properties, private_key_encrypted
+            )
+        )
         return instance
 
     def convert_java_list_to_python(self, java_list):

--- a/altastata/base_gateway.py
+++ b/altastata/base_gateway.py
@@ -79,13 +79,15 @@ class BaseGateway:
         has_py4j_jar = any(name.startswith('py4j') and name.endswith('.jar') for name in jar_names)
         has_altastata_runtime = any(
             name == 'altastata-hadoop-all.jar' or
+            (name.startswith('altastata-services-') and name.endswith('-uber.jar')) or
             (name.startswith('altastata-grpc-') and name.endswith('-uber.jar'))
             for name in jar_names
         )
         if not has_py4j_jar or not has_altastata_runtime:
             raise RuntimeError(
                 "Missing required Java runtime jars in altastata/lib. "
-                "Expected py4j*.jar and either altastata-grpc-*-uber.jar (preferred) "
+                "Expected py4j*.jar and one of: altastata-services-*-uber.jar "
+                "(preferred, current build), altastata-grpc-*-uber.jar (legacy), "
                 "or altastata-hadoop-all.jar."
             )
 

--- a/altastata/grpc_client.py
+++ b/altastata/grpc_client.py
@@ -853,18 +853,19 @@ def _resolve_local_grpc_startup_command(
         bundled_uber_jar = _find_bundled_grpc_uber_jar()
         if bundled_uber_jar is not None:
             classpath = _build_bundled_grpc_classpath(bundled_uber_jar)
-            grpc_server_command = ["java", "-cp", classpath, "com.altastata.grpc.GrpcApplication"]
+            main_class = _grpc_main_class_for_jar(bundled_uber_jar)
+            grpc_server_command = ["java", "-cp", classpath, main_class]
             if resolved_working_dir is None:
                 resolved_working_dir = os.path.dirname(bundled_uber_jar)
         else:
-            grpc_server_command = ["./gradlew", ":altastata-grpc:run"]
+            grpc_server_command = ["./gradlew", ":altastata-services:run"]
             if resolved_working_dir is None:
                 resolved_working_dir = _default_mycloud_dir()
 
-    if resolved_working_dir is None and grpc_server_command[:2] == ["./gradlew", ":altastata-grpc:run"]:
+    if resolved_working_dir is None and grpc_server_command[:2] == ["./gradlew", ":altastata-services:run"]:
         raise RuntimeError(
-            "Unable to locate bundled altastata-grpc runtime jar and unable to determine mycloud "
-            "directory for Gradle fallback. Package altastata-grpc-*-uber.jar under altastata/lib, "
+            "Unable to locate bundled altastata-services runtime jar and unable to determine mycloud "
+            "directory for Gradle fallback. Package altastata-services-*-uber.jar under altastata/lib, "
             "or pass grpc_server_command/grpc_server_working_dir, or set ALTASTATA_MYCLOUD_DIR."
         )
     return list(grpc_server_command), resolved_working_dir
@@ -882,6 +883,17 @@ def _default_mycloud_dir() -> Optional[str]:
 
 
 def _find_bundled_grpc_uber_jar() -> Optional[str]:
+    """
+    Locate the bundled gateway uber jar under ``altastata/lib``.
+
+    Preference order:
+      1. ``altastata-services-*-uber.jar`` — the unified gateway shipped by
+         current mycloud builds (Micronaut + gRPC + S3 + py4j under
+         ``com.altastata.services.AltaStataServicesApplication``).
+      2. ``altastata-grpc-*-uber.jar`` — the legacy gRPC-only gateway
+         (``com.altastata.grpc.GrpcApplication``). Kept so older wheels keep
+         working if the user pip-installed before the rename.
+    """
     try:
         jar_dir = pkg_resources.resource_filename("altastata", "lib")
     except Exception:
@@ -889,14 +901,30 @@ def _find_bundled_grpc_uber_jar() -> Optional[str]:
     if not os.path.isdir(jar_dir):
         return None
 
-    candidates = sorted(
+    services = sorted(
+        os.path.join(jar_dir, f)
+        for f in os.listdir(jar_dir)
+        if f.startswith("altastata-services-") and f.endswith("-uber.jar")
+    )
+    if services:
+        return services[-1]
+
+    legacy = sorted(
         os.path.join(jar_dir, f)
         for f in os.listdir(jar_dir)
         if f.startswith("altastata-grpc-") and f.endswith("-uber.jar")
     )
-    if not candidates:
+    if not legacy:
         return None
-    return candidates[-1]
+    return legacy[-1]
+
+
+def _grpc_main_class_for_jar(bundled_uber_jar: str) -> str:
+    """Pick the right Java main class for the given uber jar filename."""
+    name = os.path.basename(bundled_uber_jar)
+    if name.startswith("altastata-services-"):
+        return "com.altastata.services.AltaStataServicesApplication"
+    return "com.altastata.grpc.GrpcApplication"
 
 
 def _build_grpc_subprocess_env() -> Dict[str, str]:

--- a/scripts/build-bundled-artifacts.sh
+++ b/scripts/build-bundled-artifacts.sh
@@ -4,7 +4,9 @@
 # Why this exists:
 #   The altastata Python package ships two binary artifacts that this repo
 #   does not store in git:
-#     1. altastata-grpc-<ver>-uber.jar  (built from sibling mycloud/altastata-grpc)
+#     1. altastata-services-<ver>-uber.jar  (built from sibling
+#        mycloud/altastata-services — the unified Micronaut app that hosts
+#        gRPC + S3 + py4j under com.altastata.services.AltaStataServicesApplication)
 #     2. altastata/lib/altastata-console-static/  (built from sibling altastata-console)
 #   Both are deliberately gitignored under altastata/lib/ so the repo stays
 #   text-only. They are populated locally before `python -m build` so they
@@ -18,8 +20,8 @@
 #                           (default: ../mycloud relative to this repo)
 #   ALTASTATA_CONSOLE_DIR   override path to the altastata-console checkout
 #                           (default: ../altastata-console relative to this repo)
-#   SKIP_GRPC=1             skip the altastata-grpc Gradle build (use existing
-#                           altastata-grpc-*-uber.jar already present in lib/)
+#   SKIP_GRPC=1             skip the altastata-services Gradle build (use existing
+#                           altastata-services-*-uber.jar already present in lib/)
 #   SKIP_UI=1               skip the altastata-console npm build (use existing
 #                           altastata/lib/altastata-console-static/ contents)
 #
@@ -48,22 +50,35 @@ if [[ -z "${SKIP_GRPC:-}" ]]; then
         echo "       Set ALTASTATA_MYCLOUD_DIR or place mycloud next to this repo." >&2
         exit 1
     fi
-    echo "==> Building altastata-grpc uber jar in $MYCLOUD_DIR"
-    (cd "$MYCLOUD_DIR" && ./gradlew :altastata-grpc:shadowJar)
+    echo "==> Building altastata-services uber jar in $MYCLOUD_DIR"
+    (cd "$MYCLOUD_DIR" && ./gradlew :altastata-services:shadowJar)
 
-    UBER_JAR="$(ls -1 "$MYCLOUD_DIR"/altastata-grpc/build/libs/altastata-grpc-*-uber.jar 2>/dev/null | tail -1 || true)"
+    UBER_JAR="$(ls -1 "$MYCLOUD_DIR"/altastata-services/build/libs/altastata-services-*-uber.jar 2>/dev/null | tail -1 || true)"
     if [[ -z "$UBER_JAR" || ! -f "$UBER_JAR" ]]; then
-        echo "ERROR: no altastata-grpc-*-uber.jar produced under $MYCLOUD_DIR/altastata-grpc/build/libs/" >&2
+        echo "ERROR: no altastata-services-*-uber.jar produced under $MYCLOUD_DIR/altastata-services/build/libs/" >&2
         exit 1
     fi
 
-    # Remove any previously-staged uber jar so we never ship two side by side
-    # (the launcher classpath would otherwise pick the older version arbitrarily).
-    find "$LIB_DIR" -maxdepth 1 -name 'altastata-grpc-*-uber.jar' -print -delete
+    # Drop any previously-staged uber jars (both the new services name and the
+    # legacy altastata-grpc name) so we never ship two side by side; the
+    # launcher classpath would otherwise pick whichever sorts last.
+    find "$LIB_DIR" -maxdepth 1 \( -name 'altastata-services-*-uber.jar' -o -name 'altastata-grpc-*-uber.jar' \) -print -delete
     cp "$UBER_JAR" "$LIB_DIR/"
     echo "    copied $(basename "$UBER_JAR") -> altastata/lib/"
+
+    # Co-locate the BouncyCastle jars that altastata-services externalizes
+    # (they are referenced from the uber jar manifest Class-Path) so JCE
+    # signing keeps working when Python launches the gateway from altastata/lib.
+    SERVICES_LIB_DIR="$MYCLOUD_DIR/altastata-services/build/libs/lib"
+    if [[ -d "$SERVICES_LIB_DIR" ]]; then
+        for bc_jar in "$SERVICES_LIB_DIR"/bcpkix-*.jar "$SERVICES_LIB_DIR"/bcprov-*.jar "$SERVICES_LIB_DIR"/bcutil-*.jar; do
+            [[ -f "$bc_jar" ]] || continue
+            cp "$bc_jar" "$LIB_DIR/"
+            echo "    copied $(basename "$bc_jar") -> altastata/lib/"
+        done
+    fi
 else
-    echo "==> SKIP_GRPC=1, leaving altastata-grpc uber jar untouched"
+    echo "==> SKIP_GRPC=1, leaving altastata-services uber jar untouched"
 fi
 
 if [[ -z "${SKIP_UI:-}" ]]; then

--- a/tests/test_grpc_client.py
+++ b/tests/test_grpc_client.py
@@ -270,8 +270,8 @@ class GrpcClientTests(unittest.TestCase):
         mock_find_uber,
         mock_popen,
     ):
-        mock_find_uber.return_value = "/tmp/altastata-grpc-1.0.0-uber.jar"
-        mock_build_cp.return_value = "/tmp/a.jar:/tmp/b.jar:/tmp/altastata-grpc-1.0.0-uber.jar"
+        mock_find_uber.return_value = "/tmp/altastata-services-1.0.0-uber.jar"
+        mock_build_cp.return_value = "/tmp/a.jar:/tmp/b.jar:/tmp/altastata-services-1.0.0-uber.jar"
         mock_popen.return_value = MagicMock()
 
         from altastata.grpc_client import _start_local_grpc_service
@@ -280,7 +280,7 @@ class GrpcClientTests(unittest.TestCase):
         # env is built by _build_grpc_subprocess_env (covered separately) and
         # is forwarded to Popen so the Java side can pick up the bundled SPA.
         mock_popen.assert_called_once_with(
-            ["java", "-cp", "/tmp/a.jar:/tmp/b.jar:/tmp/altastata-grpc-1.0.0-uber.jar", "com.altastata.grpc.GrpcApplication"],
+            ["java", "-cp", "/tmp/a.jar:/tmp/b.jar:/tmp/altastata-services-1.0.0-uber.jar", "com.altastata.services.AltaStataServicesApplication"],
             cwd="/tmp",
             env=unittest.mock.ANY,
             stdout=unittest.mock.ANY,
@@ -304,7 +304,7 @@ class GrpcClientTests(unittest.TestCase):
         _start_local_grpc_service()
 
         mock_popen.assert_called_once_with(
-            ["./gradlew", ":altastata-grpc:run"],
+            ["./gradlew", ":altastata-services:run"],
             cwd="/work/mycloud",
             env=unittest.mock.ANY,
             stdout=unittest.mock.ANY,


### PR DESCRIPTION
## Summary

Adapt the Python wheel to the mycloud `altastata-services` consolidation (see [mycloud PR](https://github.com/SergeVil/mycloud/pulls?q=is%3Apr+head%3Afeat%2Faltastata-services)) so the wheel launches the new unified gateway instead of the deleted `altastata-grpc-*-uber.jar` / `com.altastata.grpc.GrpcApplication` pair.

Also fixes a real regression: the bare `new AltaStataFileSystem(...)` py4j reflection broke when the constructor became package-private under the `AccountRegistry` refactor. The wheel now routes through the registry's public static factories, which is also the JVM-wide instance-sharing entry point — co-hosted gRPC + py4j now resolve to the **same** `AltaStataFileSystem` (proven empirically on the mycloud side).

## What changed

- `base_gateway.py` — recognise `altastata-services-*-uber.jar` (preferred) alongside the legacy `altastata-grpc-*-uber.jar` and `altastata-hadoop-all.jar` fallbacks. Updated "missing jars" error wording.
- `grpc_client.py`:
  - prefer `altastata-services-*-uber.jar` in the bundled-jar lookup;
  - new `_grpc_main_class_for_jar` helper picks `com.altastata.services.AltaStataServicesApplication` for the new jar, falls back to `com.altastata.grpc.GrpcApplication` for old installs;
  - Gradle fallback now `./gradlew :altastata-services:run`.
- `altastata_functions.py` — both `from_account_dir` and `from_credentials` in py4j mode now go through `AccountRegistry.getOrCreateFromDir(...)` / `AccountRegistry.getOrCreate(...)`. Deprecated `grpc_setup_port` kwarg kept for signature compatibility but explicitly `del`'d.
- `scripts/build-bundled-artifacts.sh` — drives `:altastata-services:shadowJar`, stages the new uber jar **and** the externalized BouncyCastle JCE jars under `altastata/lib/`, and cleans up both the new and legacy jar name patterns so we never ship two side by side.
- `tests/test_grpc_client.py` — covers both bundled-jar launch (services + `AltaStataServicesApplication`) and Gradle fallback (`:altastata-services:run`).
- `GRPC_VS_PY4J_BENCHMARK.md` / `README-developer.md` — docs follow the rename plus the admin-PUT port migration 9880 → 9877 (Armeria handlers).

## Test plan

- [x] `python -m unittest discover -s tests` — 17/17 pass.
- [x] `bash scripts/build-bundled-artifacts.sh` produces `altastata/lib/altastata-services-*-uber.jar` + `bc{pkix,prov,util}-jdk18on-*.jar` + `altastata-console-static/`.
- [x] py4j mode smoke: `AltaStataFunctions.from_account_dir(...)` → `AccountRegistry.getOrCreateFromDir(...)` returns a usable `AltaStataFileSystem`; downstream `list_files`-class calls work.
- [x] gRPC mode smoke: wheel autospawns the JVM via `_resolve_local_grpc_startup_command`, finds the bundled `altastata-services` uber jar, launches `AltaStataServicesApplication`, and connects to Armeria :9877.
- [x] Co-hosting: JS Console (gRPC) and Python wheel (py4j) on the same JVM share a single `AltaStataFileSystem` instance via `AccountRegistry` (`AccountRegistry.size() == 1`).

Made with [Cursor](https://cursor.com)