### PR TITLE
feat(wheel): boto3 helper + enable S3 gateway in jupyter compose

### DIFF
--- a/README-developer.md
+++ b/README-developer.md
@@ -80,6 +80,46 @@ If you prefer to drive each build yourself:
   # Optional: provide your own logback.xml in altastata/lib/
   ```
 
+## boto3 / `aws` CLI against the bundled S3 gateway
+
+The `altastata-services` JVM hosts the S3-compatible REST API on port `9876`
+inside the same process that backs py4j (and gRPC). When the S3 gate is on
+(`ALTASTATA_SERVICES_S3GATEWAY_ENABLED=true`, default in the Jupyter docker
+compose), `boto3` can hit the gateway directly and reads/writes will resolve
+to the **same** `AltaStataFileSystem` instance the Python API uses, via the
+shared `AccountRegistry`. See
+`mycloud/ALTASTATA_SERVICES_UBER_DESIGN.md` §3.1 for the wiring.
+
+`AltaStataFunctions` exposes three helpers that drive the S3 admin bootstrap
+PUTs (`setUserProperties` → `setPrivateKey` → `setPassword`) and surface the
+generated access/secret pair:
+
+```python
+from altastata import AltaStataFunctions
+
+alt = AltaStataFunctions.from_account_dir("/home/jovyan/.altastata/accounts/amazon.rsa.bob123")
+alt.set_password("your-account-password")
+
+# One-liner — bootstrap on first call, dict-lookup on subsequent calls.
+s3 = alt.boto3_s3()
+print(s3.list_buckets())
+
+# Or: get kwargs and pass to any AWS SDK / s3fs / pyarrow / awswrangler.
+creds = alt.s3_credentials()
+# {'endpoint_url': 'http://127.0.0.1:9876',
+#  'aws_access_key_id': 'AKIA...',
+#  'aws_secret_access_key': '...',
+#  'region_name': 'us-east-1'}
+
+# Or: install AWS_* env vars so `!aws s3 ls`, `!s3cmd`, and any SDK that
+# reads the ambient env all "just work" from this Python process.
+alt.install_aws_env()
+```
+
+`boto3` is not in `install_requires` — pip-install it separately when you
+want the convenience wrapper (`pip install boto3`). The other two helpers
+(`s3_credentials`, `install_aws_env`) only use stdlib.
+
 ## Local Development
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ pip install altastata
 ## Features
 
 - **fsspec filesystem interface** - Use standard Python file operations with encrypted cloud storage
+- **S3-compatible API** - Drive boto3 / `aws` CLI / `s3fs` / pyarrow against the bundled S3 gateway with one helper call
 - **Real-time Event Notifications** - Listen for file share, delete, and create events
 - **LangChain Integration** - Native support for document loaders and vector stores
 - **PyTorch & TensorFlow Support** - Custom datasets for machine learning workflows
@@ -126,6 +127,56 @@ with fs.open("Public/Documents/file.txt", "r") as f:
 ```
 
 This means you can use Altastata with pandas, dask, xarray, and hundreds of other libraries without any special configuration.
+
+## boto3 / `aws` CLI / `s3fs` (S3-compatible API)
+
+The bundled `altastata-services` JVM exposes an S3-compatible REST API on
+port `9876` from inside the **same process** that backs the Python API.
+Reads/writes from `boto3` resolve to the same `AltaStataFileSystem`
+instance the Python API uses (shared `AccountRegistry`, no second cache).
+Three helpers on `AltaStataFunctions` drive the admin bootstrap and
+surface the access/secret pair the gateway generates:
+
+```python
+from altastata import AltaStataFunctions
+
+alt = AltaStataFunctions.from_account_dir("/path/to/account")
+alt.set_password("your_password")
+
+# One-liner: ready-to-use boto3 S3 client.
+s3 = alt.boto3_s3()
+print(s3.list_buckets())
+s3.put_object(Bucket="my-bucket", Key="hello.txt", Body=b"hi")
+
+# Or: just the kwargs — pass to any AWS SDK / s3fs / pyarrow / awswrangler.
+creds = alt.s3_credentials()
+# {'endpoint_url': 'http://127.0.0.1:9876',
+#  'aws_access_key_id': 'AKIA...',
+#  'aws_secret_access_key': '...',
+#  'region_name': 'us-east-1'}
+
+import s3fs
+fs = s3fs.S3FileSystem(
+    key=creds["aws_access_key_id"],
+    secret=creds["aws_secret_access_key"],
+    client_kwargs={"endpoint_url": creds["endpoint_url"]},
+)
+
+# Or: install AWS_* env vars so `!aws s3 ls`, `!s3cmd ls`, and any SDK
+# that reads the ambient environment all "just work" — handy from Jupyter
+# notebook shell cells.
+alt.install_aws_env()
+```
+
+Requirements:
+
+- The S3 gateway must be enabled on the JVM
+  (`ALTASTATA_SERVICES_S3GATEWAY_ENABLED=true`, which is the **default in the
+  bundled `jupyter-datascience` docker compose**).
+- `boto3` is **not** in the wheel's `install_requires` — install it
+  separately (`pip install boto3`) only if you want the
+  `alt.boto3_s3()` convenience. `s3_credentials()` and `install_aws_env()`
+  use stdlib only.
 
 ## Event Listener
 

--- a/altastata/altastata_functions.py
+++ b/altastata/altastata_functions.py
@@ -1,20 +1,68 @@
 from .base_gateway import BaseGateway
 from .grpc_client import AltaStataGrpcClient, GrpcEndpoint
 
-from typing import List, Any, Dict, Optional, Union, Callable
+from typing import List, Any, Dict, Optional, Union, Callable, Tuple
 from py4j.java_gateway import JavaGateway, JavaObject, GatewayParameters, CallbackServerParameters, java_import
 from py4j.java_collections import JavaList
 
 import base64
 import io
+import json
 import os
 import tempfile
 import time
 import threading
 import queue
+import urllib.error
+import urllib.parse
+import urllib.request
 
 PLAIN_CHUNK_MAX_SIZE = 8 * 1024 * 1024  # 8MB - matches Java Constants.PLAIN_CHUNK_MAX_SIZE
 TEMP_FILE_THRESHOLD = 64 * 1024 * 1024  # 64MB — above this, use temp file for performance
+
+
+def _parse_user_name_from_properties(text: str) -> str:
+    """Extract the ``myuser`` value from a user.properties text blob.
+
+    Mirrors what {@code com.altastata.utils.Account} does on the Java side
+    so the boto3 helper can derive the same user name that
+    ``AccountRegistry.getOrCreate`` / ``getOrCreateFromDir`` would have
+    chosen.
+
+    Raises:
+        ValueError: if no ``myuser=...`` line is present.
+    """
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line.startswith("myuser="):
+            value = line.split("=", 1)[1].strip()
+            if value:
+                return value
+    raise ValueError("user_properties does not contain a non-empty 'myuser=' line")
+
+
+def _http_put_text(url: str, body: str, timeout_s: float = 30.0) -> Tuple[int, bytes]:
+    """Issue a ``PUT`` with a plain-text body using stdlib urllib.
+
+    Used by the S3 boto3 helper to drive the three admin bootstrap PUTs
+    (setUserProperties / setPrivateKey / setPassword). Kept on stdlib so we
+    don't have to pull ``requests`` into install_requires just for this one
+    code path.
+
+    Returns:
+        (status_code, body_bytes). Caller decides how to handle non-2xx.
+    """
+    req = urllib.request.Request(
+        url=url,
+        data=body.encode("utf-8"),
+        method="PUT",
+        headers={"Content-Type": "text/plain"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read() or b""
 
 
 
@@ -93,6 +141,19 @@ class AltaStataFunctions(BaseGateway):
         self.grpc_client = grpc_client
         self._event_listeners = []  # Track registered listeners
 
+        # Material the S3 boto3 helper needs to drive the admin bootstrap
+        # PUTs (setUserProperties / setPrivateKey / setPassword) without
+        # asking the caller to repeat what they already gave us.
+        # Populated by from_account_dir / from_credentials below.
+        self._account_dir_path: Optional[str] = None
+        self._user_properties: Optional[str] = None
+        self._private_key_encrypted: Optional[str] = None
+        self._cached_password: Optional[str] = None
+        # Cache of bootstrapped S3 credentials keyed by endpoint URL. The
+        # access/secret pair never changes for a given (endpoint, user) so a
+        # second `s3_credentials()` / `boto3_s3()` call is a dict lookup.
+        self._s3_credentials_cache: Dict[str, Dict[str, str]] = {}
+
     @classmethod
     def from_account_dir(
         cls,
@@ -133,13 +194,16 @@ class AltaStataFunctions(BaseGateway):
                 endpoint=endpoint,
                 auto_start_server=grpc_auto_start_server,
             )
-            return cls(
+            instance = cls(
                 port=port,
                 enable_callback_server=enable_callback_server,
                 callback_server_port=callback_server_port,
                 transport="grpc",
                 grpc_client=client,
             )
+            instance._account_dir_path = account_dir_path
+            instance._cached_password = password
+            return instance
 
         instance = cls(
             port=port,
@@ -155,6 +219,8 @@ class AltaStataFunctions(BaseGateway):
         instance.altastata_file_system = (
             instance.gateway.jvm.com.altastata.api.AccountRegistry.getOrCreateFromDir(account_dir_path)
         )
+        instance._account_dir_path = account_dir_path
+        instance._cached_password = password
         return instance
 
     @classmethod
@@ -198,13 +264,17 @@ class AltaStataFunctions(BaseGateway):
                 endpoint=endpoint,
                 auto_start_server=grpc_auto_start_server,
             )
-            return cls(
+            instance = cls(
                 port=port,
                 enable_callback_server=enable_callback_server,
                 callback_server_port=callback_server_port,
                 transport="grpc",
                 grpc_client=client,
             )
+            instance._user_properties = user_properties
+            instance._private_key_encrypted = private_key_encrypted
+            instance._cached_password = password
+            return instance
 
         instance = cls(
             port=port,
@@ -219,6 +289,9 @@ class AltaStataFunctions(BaseGateway):
                 user_properties, private_key_encrypted
             )
         )
+        instance._user_properties = user_properties
+        instance._private_key_encrypted = private_key_encrypted
+        instance._cached_password = password
         return instance
 
     def convert_java_list_to_python(self, java_list):
@@ -257,12 +330,230 @@ class AltaStataFunctions(BaseGateway):
         return java_array
 
     def set_password(self, account_password: str):
+        # Remember the plaintext so s3_credentials() / boto3_s3() / install_aws_env()
+        # can drive the S3 admin PUTs without forcing the caller to retype it.
+        self._cached_password = account_password
         if self.transport == "grpc":
             return self.grpc_client.set_password(account_password)
         result = self.altastata_file_system.setPassword(account_password)
 
         # Process the result
         return result
+
+    # ------------------------------------------------------------------ #
+    # S3 / boto3 bridge                                                  #
+    # ------------------------------------------------------------------ #
+    def s3_credentials(
+        self,
+        *,
+        password: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        region: str = "us-east-1",
+    ) -> Dict[str, str]:
+        """Bootstrap and return boto3-ready S3 credentials.
+
+        Drives the three admin PUTs against the S3 gateway running inside the
+        same ``altastata-services`` JVM that backs this Python session
+        (setUserProperties → setPrivateKey → setPassword), then returns the
+        access/secret pair the gateway generated.
+
+        Args:
+            password: Plaintext account password used to unlock the encrypted
+                private key on the gateway side. Falls back to the value
+                cached by :meth:`set_password` (or the ``password`` kwarg
+                passed to :meth:`from_account_dir` / :meth:`from_credentials`).
+                Required for non-HSM users; HSM/HPCS users can pass ``""``.
+            endpoint: Base URL of the S3 gateway. Defaults to
+                ``http://127.0.0.1:9876`` for py4j sessions (JVM in the same
+                process) and ``http://<grpc-host>:9876`` for gRPC sessions.
+            region: AWS region for SigV4. The gateway is region-agnostic but
+                boto3 still demands a value; ``us-east-1`` is the safe default.
+
+        Returns:
+            Dict with keys ``endpoint_url``, ``aws_access_key_id``,
+            ``aws_secret_access_key``, ``region_name`` — directly usable as
+            ``boto3.client('s3', **result)``.
+
+        Caveat:
+            The third PUT (``setPassword``) calls
+            ``AltaStataFileSystem.setPassword(...)`` on the shared instance
+            stored in ``AccountRegistry``. Passing the same password you
+            already used for this session is a no-op; passing a different
+            one mutates the shared instance. The planned unified
+            ``UserAdminRegistry`` (see
+            ``mycloud/ALTASTATA_SERVICES_UBER_DESIGN.md`` §3.1) will close
+            this gap.
+        """
+        endpoint = (endpoint or self._resolve_s3_endpoint()).rstrip("/")
+
+        cached = self._s3_credentials_cache.get(endpoint)
+        if cached is not None and cached.get("region_name") == region:
+            return dict(cached)
+
+        pw = password if password is not None else self._cached_password
+        if pw is None:
+            raise ValueError(
+                "s3_credentials() requires a password. Either pass "
+                "password=... explicitly, or call set_password() (or pass "
+                "password=... to from_account_dir / from_credentials) first."
+            )
+
+        user_name, user_properties, private_key_encrypted = (
+            self._read_bootstrap_material()
+        )
+
+        def _put(path: str, body: str) -> Dict[str, Any]:
+            status, raw = _http_put_text(f"{endpoint}{path}", body)
+            if status < 200 or status >= 300:
+                raise RuntimeError(
+                    f"S3 admin PUT {path} failed with HTTP {status}: "
+                    f"{raw[:500].decode('utf-8', errors='replace')}"
+                )
+            if not raw:
+                return {}
+            try:
+                return json.loads(raw)
+            except ValueError:
+                return {"_raw": raw.decode("utf-8", errors="replace")}
+
+        # setUserProperties / setPrivateKey are idempotent on the S3 side
+        # ONLY when no UserData exists yet. Once the user has been bootstrapped
+        # in this JVM (this same wheel call, an earlier wheel call, the
+        # standalone S3 daemon, or external admin tooling), the gateway
+        # refuses both PUTs with HTTP 400 unless `?password=<current>` is
+        # supplied so it can validate the caller against the existing private
+        # key (S3Controller.setUserProperties / setPrivateKey). Always send
+        # the password as query — for fresh users it is ignored, for known
+        # users it unblocks re-bootstrap with the same credentials.
+        pw_q = "?password=" + urllib.parse.quote(pw, safe="")
+        _put(f"/setUserProperties/{user_name}{pw_q}", user_properties)
+        _put(f"/setPrivateKey/{user_name}{pw_q}", private_key_encrypted)
+        body = _put(f"/setPassword/{user_name}", pw)
+
+        access_key = body.get("accessKey")
+        secret_key = body.get("secretKey")
+        if not access_key or not secret_key:
+            raise RuntimeError(
+                "S3 gateway did not return accessKey/secretKey from "
+                f"setPassword; response was: {body}"
+            )
+
+        creds = {
+            "endpoint_url": endpoint,
+            "aws_access_key_id": access_key,
+            "aws_secret_access_key": secret_key,
+            "region_name": region,
+        }
+        self._s3_credentials_cache[endpoint] = dict(creds)
+        return creds
+
+    def boto3_s3(self, **overrides):
+        """Return a ready-to-use boto3 S3 client.
+
+        Equivalent to::
+
+            boto3.client('s3', **self.s3_credentials(), **overrides)
+
+        Any keyword in ``overrides`` wins over the helper's defaults — use
+        this to pass ``config=botocore.config.Config(...)``, override
+        ``endpoint_url`` for a remote deployment, etc.
+
+        Requires ``boto3`` to be installed in the environment; raises
+        ``ImportError`` with a clear hint otherwise. ``boto3`` is not in
+        ``install_requires`` because not every wheel consumer wants the AWS
+        SDK on the import path.
+        """
+        try:
+            import boto3
+        except ImportError as e:
+            raise ImportError(
+                "boto3 is required for AltaStataFunctions.boto3_s3(). "
+                "Install it with `pip install boto3`."
+            ) from e
+        creds = self.s3_credentials()
+        return boto3.client("s3", **{**creds, **overrides})
+
+    def install_aws_env(
+        self,
+        *,
+        password: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        region: str = "us-east-1",
+    ) -> Dict[str, str]:
+        """Bootstrap S3 credentials and export them as ``AWS_*`` env vars.
+
+        Sets four variables in ``os.environ`` so that subprocess shells
+        (``!aws s3 ls``, ``!s3cmd``, etc.) and any AWS SDK that reads the
+        ambient environment can see them without further configuration:
+
+        - ``AWS_ACCESS_KEY_ID``
+        - ``AWS_SECRET_ACCESS_KEY``
+        - ``AWS_DEFAULT_REGION``
+        - ``AWS_ENDPOINT_URL_S3`` (picked up by boto3 ≥ 1.30 and the
+          ``aws`` CLI v2 via ``--endpoint-url`` shorthand)
+
+        Returns:
+            The dict that was applied to ``os.environ`` — handy for
+            eval-exporting into a parent shell.
+        """
+        creds = self.s3_credentials(password=password, endpoint=endpoint, region=region)
+        aws_env = {
+            "AWS_ACCESS_KEY_ID": creds["aws_access_key_id"],
+            "AWS_SECRET_ACCESS_KEY": creds["aws_secret_access_key"],
+            "AWS_DEFAULT_REGION": creds["region_name"],
+            "AWS_ENDPOINT_URL_S3": creds["endpoint_url"],
+        }
+        os.environ.update(aws_env)
+        return aws_env
+
+    def _resolve_s3_endpoint(self) -> str:
+        """Best-effort default URL for the S3 gateway.
+
+        - gRPC mode: same host as the gRPC target, port 9876.
+        - py4j mode: ``http://127.0.0.1:9876`` (JVM lives in the same
+          process tree).
+        """
+        if self.transport == "grpc" and self.grpc_client is not None:
+            host = self.grpc_client.endpoint.host
+            return f"http://{host}:9876"
+        return "http://127.0.0.1:9876"
+
+    def _read_bootstrap_material(self) -> Tuple[str, str, str]:
+        """Resolve ``(user_name, user_properties, private_key_encrypted)``.
+
+        For instances built via :meth:`from_account_dir`, reads the
+        ``*user.properties`` file and ``private.key`` from disk on each call
+        so updates to those files take effect on the next bootstrap.
+        For :meth:`from_credentials` instances, returns the strings supplied
+        at construction.
+        """
+        if self._account_dir_path is not None:
+            props_path = None
+            for fname in sorted(os.listdir(self._account_dir_path)):
+                if fname.endswith("user.properties"):
+                    props_path = os.path.join(self._account_dir_path, fname)
+                    break
+            if props_path is None:
+                raise FileNotFoundError(
+                    f"No *user.properties file in account dir {self._account_dir_path}"
+                )
+            with open(props_path, "r", encoding="utf-8") as f:
+                user_properties = f.read()
+            key_path = os.path.join(self._account_dir_path, "private.key")
+            with open(key_path, "r", encoding="utf-8") as f:
+                private_key_encrypted = f.read()
+        elif self._user_properties is not None and self._private_key_encrypted is not None:
+            user_properties = self._user_properties
+            private_key_encrypted = self._private_key_encrypted
+        else:
+            raise RuntimeError(
+                "S3 bootstrap material unavailable. Construct this "
+                "AltaStataFunctions via from_account_dir(path) or "
+                "from_credentials(user_properties, private_key)."
+            )
+
+        user_name = _parse_user_name_from_properties(user_properties)
+        return user_name, user_properties, private_key_encrypted
 
     def create_file(self, cloud_file_path, buffer=None):
         """

--- a/containers/jupyter/docker-compose.yml
+++ b/containers/jupyter/docker-compose.yml
@@ -17,8 +17,13 @@ services:
       # without touching the container; default 9877. Set it to e.g. 9879
       # in .env if 9877 is occupied (Jupyter + RAG side-by-side: RAG default
       # is 9878).
+      # ALTASTATA_S3_HOST_PORT is the S3-compatible REST API (default 9876)
+      # so boto3 / aws CLI / s3fs / etc. can hit the gateway from the host.
+      # Only used when ALTASTATA_SERVICES_S3GATEWAY_ENABLED=1; otherwise the
+      # JVM still binds 9876 internally but routes return 404 (no controller).
       - "127.0.0.1:8888:8888"
       - "127.0.0.1:${ALTASTATA_CONSOLE_UI_HOST_PORT:-9877}:9877"
+      - "127.0.0.1:${ALTASTATA_S3_HOST_PORT:-9876}:9876"
     volumes:
       - ../../examples/pytorch-example:/home/jovyan/pytorch-example
       - ../../examples/tensorflow-example:/home/jovyan/tensorflow-example
@@ -31,6 +36,15 @@ services:
       # Console UI auto-starts by default in this stack. Set to 0 in .env for
       # Jupyter-only. ALTASTATA_GRPC_BIND_ADDRESS is baked in the image.
       - ENABLE_ALTASTATA_CONSOLE_UI=${ENABLE_ALTASTATA_CONSOLE_UI:-1}
+      # S3 gateway gate inside the altastata-services JVM. Default ON in this
+      # stack so notebooks can drive boto3 / aws CLI against the same data
+      # the py4j Python API sees (shared AccountRegistry → same
+      # AltaStataFileSystem inside one JVM). The value is consumed by
+      # @Requires(value="true") on S3Controller, so it MUST be the literal
+      # string "true" or "false" (not "1"/"0"). Set to "false" in .env to
+      # bind only gRPC + py4j (the JVM still listens on 9876 but with no S3
+      # routes registered).
+      - ALTASTATA_SERVICES_S3GATEWAY_ENABLED=${ALTASTATA_SERVICES_S3GATEWAY_ENABLED:-true}
     networks:
       - altastata-network
     restart: unless-stopped

--- a/tests/test_s3_helper.py
+++ b/tests/test_s3_helper.py
@@ -1,0 +1,423 @@
+"""Unit tests for AltaStataFunctions S3 / boto3 helper surface.
+
+These tests do not boot a real JVM. They mock out:
+  * the py4j gateway construction (via AltaStataFunctions.__new__ + manual
+    field assignment), so we do not depend on a running altastata-services
+    process,
+  * the bootstrap PUTs (via the module-level ``_http_put_text`` symbol),
+  * and ``boto3.client`` (so ``boto3`` does not need to be installed for the
+    test suite).
+
+They exercise the public surface of s3_credentials(), boto3_s3(),
+install_aws_env(), and the underlying _resolve_s3_endpoint() /
+_read_bootstrap_material() helpers.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from altastata.altastata_functions import (
+    AltaStataFunctions,
+    _parse_user_name_from_properties,
+    _http_put_text,
+)
+
+
+def _make_instance(transport: str = "py4j") -> AltaStataFunctions:
+    """Build an AltaStataFunctions without touching any real JVM / gRPC.
+
+    We bypass __init__ since it spins up a py4j gateway in py4j mode and we
+    only care about the helper surface in unit tests.
+    """
+    inst = AltaStataFunctions.__new__(AltaStataFunctions)
+    inst.transport = transport
+    inst.gateway = None
+    inst.altastata_file_system = None
+    inst.grpc_client = None
+    inst._event_listeners = []
+    inst._account_dir_path = None
+    inst._user_properties = None
+    inst._private_key_encrypted = None
+    inst._cached_password = None
+    inst._s3_credentials_cache = {}
+    return inst
+
+
+class ParseUserNameTests(unittest.TestCase):
+    def test_picks_myuser_line(self):
+        self.assertEqual(
+            "bob123",
+            _parse_user_name_from_properties(
+                "region=us-east-1\nmyuser=bob123\naccounttype=amazon\n"
+            ),
+        )
+
+    def test_strips_whitespace(self):
+        self.assertEqual(
+            "alice",
+            _parse_user_name_from_properties("myuser=  alice  \n"),
+        )
+
+    def test_ignores_commented_line(self):
+        with self.assertRaises(ValueError):
+            _parse_user_name_from_properties("# myuser=ghost\nfoo=bar\n")
+
+    def test_missing_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_user_name_from_properties("region=us-east-1\n")
+
+    def test_empty_value_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_user_name_from_properties("myuser=\n")
+
+
+class ResolveS3EndpointTests(unittest.TestCase):
+    def test_py4j_defaults_to_loopback(self):
+        inst = _make_instance("py4j")
+        self.assertEqual("http://127.0.0.1:9876", inst._resolve_s3_endpoint())
+
+    def test_grpc_uses_grpc_host(self):
+        inst = _make_instance("grpc")
+        inst.grpc_client = MagicMock()
+        inst.grpc_client.endpoint.host = "altastata.internal"
+        self.assertEqual(
+            "http://altastata.internal:9876", inst._resolve_s3_endpoint()
+        )
+
+
+class ReadBootstrapMaterialTests(unittest.TestCase):
+    def test_from_credentials_mode_returns_stored_strings(self):
+        inst = _make_instance("py4j")
+        inst._user_properties = "myuser=bob\n"
+        inst._private_key_encrypted = "PRIVATE_KEY_BYTES"
+        user_name, props, key = inst._read_bootstrap_material()
+        self.assertEqual("bob", user_name)
+        self.assertEqual("myuser=bob\n", props)
+        self.assertEqual("PRIVATE_KEY_BYTES", key)
+
+    def test_from_account_dir_mode_reads_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            props_path = os.path.join(
+                tmpdir, "altastata-myorg-bob.user.properties"
+            )
+            with open(props_path, "w", encoding="utf-8") as f:
+                f.write("myuser=bob\nregion=us-east-1\n")
+            with open(os.path.join(tmpdir, "private.key"), "w", encoding="utf-8") as f:
+                f.write("PK_PEM")
+
+            inst = _make_instance("py4j")
+            inst._account_dir_path = tmpdir
+            user_name, props, key = inst._read_bootstrap_material()
+            self.assertEqual("bob", user_name)
+            self.assertIn("myuser=bob", props)
+            self.assertEqual("PK_PEM", key)
+
+    def test_missing_material_raises(self):
+        inst = _make_instance("py4j")
+        with self.assertRaises(RuntimeError):
+            inst._read_bootstrap_material()
+
+    def test_account_dir_missing_properties_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            inst = _make_instance("py4j")
+            inst._account_dir_path = tmpdir
+            with self.assertRaises(FileNotFoundError):
+                inst._read_bootstrap_material()
+
+
+class S3CredentialsTests(unittest.TestCase):
+    def _put_responder(self):
+        """Return a ``_http_put_text`` mock that mimics the S3 admin PUTs."""
+        def _put(url, body, timeout_s=30.0):
+            if "/setUserProperties/" in url:
+                return 200, b'{"status":"success"}'
+            if "/setPrivateKey/" in url:
+                return 200, b'{"status":"success"}'
+            if "/setPassword/" in url:
+                return 200, json.dumps({
+                    "status": "success",
+                    "accessKey": "AKIAFAKE",
+                    "secretKey": "SECRETFAKE",
+                }).encode("utf-8")
+            return 404, b'{"error":"unknown"}'
+        return _put
+
+    @patch("altastata.altastata_functions._http_put_text")
+    def test_returns_boto3_kwargs(self, mock_put):
+        mock_put.side_effect = self._put_responder()
+        inst = _make_instance("py4j")
+        inst._user_properties = "myuser=bob\n"
+        inst._private_key_encrypted = "PRIVATE_KEY"
+        inst._cached_password = "123"
+
+        creds = inst.s3_credentials()
+
+        self.assertEqual(
+            {
+                "endpoint_url": "http://127.0.0.1:9876",
+                "aws_access_key_id": "AKIAFAKE",
+                "aws_secret_access_key": "SECRETFAKE",
+                "region_name": "us-east-1",
+            },
+            creds,
+        )
+        # Three PUTs in the expected order, and the first two carry
+        # ?password=<urlencoded> so re-bootstrapping an already-known user
+        # succeeds (see s3_credentials() body for the rationale).
+        urls_called = [c.args[0] for c in mock_put.call_args_list]
+        self.assertEqual(3, len(urls_called))
+        self.assertIn("/setUserProperties/bob?password=123", urls_called[0])
+        self.assertIn("/setPrivateKey/bob?password=123", urls_called[1])
+        self.assertIn("/setPassword/bob", urls_called[2])
+        # setPassword sends password in body, not query.
+        self.assertNotIn("?password=", urls_called[2])
+
+    @patch("altastata.altastata_functions._http_put_text")
+    def test_password_is_url_encoded(self, mock_put):
+        mock_put.side_effect = self._put_responder()
+        inst = _make_instance("py4j")
+        inst._user_properties = "myuser=bob\n"
+        inst._private_key_encrypted = "PK"
+        # Password with characters that MUST be URL-escaped to survive a
+        # query-string round-trip on S3Controller's validatePassword path.
+        inst._cached_password = "p w&p=1?#/"
+
+        inst.s3_credentials()
+
+        urls = [c.args[0] for c in mock_put.call_args_list]
+        # Reserved characters end up percent-encoded; literal `?` / `&` /
+        # `=` from the password must not split the query string.
+        encoded = "p%20w%26p%3D1%3F%23%2F"
+        self.assertIn(f"?password={encoded}", urls[0])
+        self.assertIn(f"?password={encoded}", urls[1])
+
+    @patch("altastata.altastata_functions._http_put_text")
+    def test_caches_result_per_endpoint(self, mock_put):
+        mock_put.side_effect = self._put_responder()
+        inst = _make_instance("py4j")
+        inst._user_properties = "myuser=bob\n"
+        inst._private_key_encrypted = "PK"
+        inst._cached_password = "p"
+
+        inst.s3_credentials()
+        inst.s3_credentials()
+        # Three PUTs total, not six — the second call must hit the cache.
+        self.assertEqual(3, mock_put.call_count)
+
+    @patch("altastata.altastata_functions._http_put_text")
+    def test_explicit_endpoint_override(self, mock_put):
+        mock_put.side_effect = self._put_responder()
+        inst = _make_instance("py4j")
+        inst._user_properties = "myuser=bob\n"
+        inst._private_key_encrypted = "PK"
+        inst._cached_password = "p"
+
+        creds = inst.s3_credentials(endpoint="http://altastata.example:19876/")
+        self.assertEqual("http://altastata.example:19876", creds["endpoint_url"])
+        for call in mock_put.call_args_list:
+            self.assertTrue(call.args[0].startswith("http://altastata.example:19876/"))
+
+    @patch("altastata.altastata_functions._http_put_text")
+    def test_already_bootstrapped_user_recovers(self, mock_put):
+        """The S3 gateway rejects setUserProperties / setPrivateKey with 400
+        once UserData exists, unless ?password= is supplied. The helper
+        always passes it, so re-bootstrapping from a fresh wheel process
+        against an already-warmed JVM must succeed."""
+        calls = {"n": 0}
+
+        def _put(url, body, timeout_s=30.0):
+            calls["n"] += 1
+            if "/setUserProperties/" in url:
+                # Mimic S3Controller: reject when no ?password=, accept when
+                # present (regardless of value — we already covered the
+                # validation surface with a separate test).
+                if "?password=" not in url:
+                    return 400, (
+                        b'{"error": "User properties already exist. '
+                        b'Password required for modification."}'
+                    )
+                return 200, b'{"status":"success"}'
+            if "/setPrivateKey/" in url:
+                if "?password=" not in url:
+                    return 400, b'{"error":"Private key already exists."}'
+                return 200, b'{"status":"success"}'
+            if "/setPassword/" in url:
+                return 200, json.dumps({
+                    "accessKey": "AK_REBOOT", "secretKey": "SK_REBOOT"
+                }).encode("utf-8")
+            return 404, b''
+
+        mock_put.side_effect = _put
+
+        inst = _make_instance("py4j")
+        inst._user_properties = "myuser=bob\n"
+        inst._private_key_encrypted = "PK"
+        inst._cached_password = "123"
+
+        creds = inst.s3_credentials()
+        self.assertEqual("AK_REBOOT", creds["aws_access_key_id"])
+        self.assertEqual(3, calls["n"])
+
+    def test_missing_password_raises(self):
+        inst = _make_instance("py4j")
+        inst._user_properties = "myuser=bob\n"
+        inst._private_key_encrypted = "PK"
+        with self.assertRaises(ValueError):
+            inst.s3_credentials()
+
+    @patch("altastata.altastata_functions._http_put_text")
+    def test_explicit_password_overrides_cache(self, mock_put):
+        mock_put.side_effect = self._put_responder()
+        inst = _make_instance("py4j")
+        inst._user_properties = "myuser=bob\n"
+        inst._private_key_encrypted = "PK"
+        inst._cached_password = "wrong"
+
+        inst.s3_credentials(password="correct")
+        last_call = mock_put.call_args_list[-1]
+        # body of the third PUT is the password (second positional arg).
+        self.assertEqual("correct", last_call.args[1])
+
+    @patch("altastata.altastata_functions._http_put_text")
+    def test_setPassword_500_surfaces_as_runtime_error(self, mock_put):
+        def _put(url, body, timeout_s=30.0):
+            if "/setPassword/" in url:
+                return 500, b"server error"
+            return 200, b'{"status":"success"}'
+        mock_put.side_effect = _put
+
+        inst = _make_instance("py4j")
+        inst._user_properties = "myuser=bob\n"
+        inst._private_key_encrypted = "PK"
+        inst._cached_password = "p"
+
+        with self.assertRaises(RuntimeError):
+            inst.s3_credentials()
+
+    @patch("altastata.altastata_functions._http_put_text")
+    def test_grpc_mode_default_endpoint_follows_grpc_host(self, mock_put):
+        mock_put.side_effect = self._put_responder()
+        inst = _make_instance("grpc")
+        inst.grpc_client = MagicMock()
+        inst.grpc_client.endpoint.host = "altastata.internal"
+        inst._user_properties = "myuser=bob\n"
+        inst._private_key_encrypted = "PK"
+        inst._cached_password = "p"
+
+        creds = inst.s3_credentials()
+        self.assertEqual("http://altastata.internal:9876", creds["endpoint_url"])
+
+
+class Boto3ClientTests(unittest.TestCase):
+    @patch("altastata.altastata_functions._http_put_text")
+    def test_boto3_s3_passes_creds_and_overrides(self, mock_put):
+        def _put(url, body, timeout_s=30.0):
+            if "/setPassword/" in url:
+                return 200, json.dumps({
+                    "accessKey": "AK", "secretKey": "SK"
+                }).encode("utf-8")
+            return 200, b'{"status":"success"}'
+        mock_put.side_effect = _put
+
+        fake_boto3 = MagicMock()
+        fake_boto3.client.return_value = "<s3-client>"
+        with patch.dict(sys.modules, {"boto3": fake_boto3}):
+            inst = _make_instance("py4j")
+            inst._user_properties = "myuser=bob\n"
+            inst._private_key_encrypted = "PK"
+            inst._cached_password = "p"
+
+            client = inst.boto3_s3(verify=False)
+
+        self.assertEqual("<s3-client>", client)
+        fake_boto3.client.assert_called_once()
+        call_args, call_kwargs = fake_boto3.client.call_args
+        self.assertEqual(("s3",), call_args)
+        self.assertEqual("http://127.0.0.1:9876", call_kwargs["endpoint_url"])
+        self.assertEqual("AK", call_kwargs["aws_access_key_id"])
+        self.assertEqual("SK", call_kwargs["aws_secret_access_key"])
+        self.assertIs(False, call_kwargs["verify"])
+
+    def test_boto3_s3_missing_dependency_raises_importerror(self):
+        inst = _make_instance("py4j")
+        inst._user_properties = "myuser=bob\n"
+        inst._private_key_encrypted = "PK"
+        inst._cached_password = "p"
+
+        # Force `import boto3` inside boto3_s3() to fail.
+        prev = sys.modules.get("boto3", None)
+        sys.modules["boto3"] = None
+        try:
+            with self.assertRaises(ImportError):
+                inst.boto3_s3()
+        finally:
+            if prev is not None:
+                sys.modules["boto3"] = prev
+            else:
+                del sys.modules["boto3"]
+
+
+class InstallAwsEnvTests(unittest.TestCase):
+    @patch("altastata.altastata_functions._http_put_text")
+    def test_install_aws_env_populates_environ(self, mock_put):
+        def _put(url, body, timeout_s=30.0):
+            if "/setPassword/" in url:
+                return 200, json.dumps({
+                    "accessKey": "AK_ENV", "secretKey": "SK_ENV"
+                }).encode("utf-8")
+            return 200, b'{"status":"success"}'
+        mock_put.side_effect = _put
+
+        inst = _make_instance("py4j")
+        inst._user_properties = "myuser=bob\n"
+        inst._private_key_encrypted = "PK"
+        inst._cached_password = "p"
+
+        # Snapshot env so the test does not bleed into siblings.
+        captured = {
+            k: os.environ.get(k)
+            for k in (
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_DEFAULT_REGION",
+                "AWS_ENDPOINT_URL_S3",
+            )
+        }
+        try:
+            aws_env = inst.install_aws_env()
+            self.assertEqual("AK_ENV", os.environ["AWS_ACCESS_KEY_ID"])
+            self.assertEqual("SK_ENV", os.environ["AWS_SECRET_ACCESS_KEY"])
+            self.assertEqual("us-east-1", os.environ["AWS_DEFAULT_REGION"])
+            self.assertEqual("http://127.0.0.1:9876", os.environ["AWS_ENDPOINT_URL_S3"])
+            self.assertEqual("AK_ENV", aws_env["AWS_ACCESS_KEY_ID"])
+        finally:
+            for k, v in captured.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+
+class SetPasswordCachesTests(unittest.TestCase):
+    @patch("altastata.altastata_functions.AltaStataGrpcClient")
+    def test_set_password_caches_value(self, mock_grpc_cls):
+        mock_client = MagicMock()
+        mock_grpc_cls.from_credentials.return_value = mock_client
+
+        f = AltaStataFunctions.from_credentials(
+            "myuser=bob\n",
+            "PK",
+            transport="grpc",
+        )
+        # Pre-condition: no cached password (no constructor kwarg).
+        self.assertIsNone(f._cached_password)
+        f.set_password("hunter2")
+        self.assertEqual("hunter2", f._cached_password)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Wire boto3 / `aws` CLI / `s3fs` / pyarrow into the bundled `altastata-services` S3 gateway from Python without forcing the caller to drive HTTP admin endpoints by hand.

The point is to make this work in one line from a Jupyter notebook in the `altastata-jupyter-datascience` container while reusing the **same** `AltaStataFileSystem` instance the py4j Python API already holds (shared `AccountRegistry` inside one JVM, no second cache, no duplicate connection pool). See [`mycloud/ALTASTATA_SERVICES_UBER_DESIGN.md`](https://github.com/SergeVil/mycloud/blob/openshift/ALTASTATA_SERVICES_UBER_DESIGN.md) §3.1 for the wiring.

### Two-part change

**A — Jupyter docker compose**
- Forward port 9876 (`ALTASTATA_S3_HOST_PORT` override).
- Default `ALTASTATA_SERVICES_S3GATEWAY_ENABLED=true` so S3 routes are live. Value must be the literal `true`/`false` since `S3Controller` is gated by Micronaut `@Requires(value="true")`.

**B — `AltaStataFunctions` helpers**
- `s3_credentials(password=..., endpoint=..., region=...) -> dict` — drives the three admin PUTs (`setUserProperties` → `setPrivateKey` → `setPassword`) and returns boto3-ready kwargs. Cached per-endpoint.
- `boto3_s3(**overrides)` — one-liner equivalent of `boto3.client('s3', **s3_credentials(), **overrides)`. `boto3` is imported lazily; not added to `install_requires`.
- `install_aws_env(...)` — exports `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_DEFAULT_REGION` / `AWS_ENDPOINT_URL_S3` to `os.environ`, so `!aws s3 ls` / `!s3cmd` / any SDK that reads ambient AWS env vars works from notebook cells.

Bootstrap material plumbing is now stashed on the instance by `from_account_dir` / `from_credentials` / `set_password`, so callers do not have to retype anything.

### Idempotency fix (found during E2E)

`S3Controller.setUserProperties` / `setPrivateKey` reject a second bootstrap of an already-known user with HTTP 400 unless `?password=<current>` is attached as a query string so the controller can re-validate the caller against the existing encrypted private key. The helper therefore always appends a URL-encoded `?password=` to those two PUTs (and only those two — `setPassword` takes the password in the body). For fresh users the query is silently ignored; for warm JVMs the helper still succeeds.

## Test plan

- [x] **Unit (41 tests, all green):** new `tests/test_s3_helper.py` covers user_name parsing, endpoint resolution (py4j vs gRPC), bootstrap-material plumbing (account dir / in-memory / error cases), URL-encoded passwords in the query, re-bootstrap against a warm gateway (server says 400 without `?password=`, helper still succeeds), cache, endpoint override, explicit-password override, `setPassword` 500 → RuntimeError, `boto3_s3` kwarg merge + clean ImportError when `boto3` missing, `install_aws_env` populates `os.environ`, and `set_password` caches the value.

- [x] **End-to-end against the live JVM**, from inside `altastata-jupyter-datascience-arm64` with a real `amazon.rsa.bob123` account:
  - `alt.boto3_s3().list_buckets()` → HTTP 200 + `altastata-bucket` (2023-01-01).
  - `alt.boto3_s3().list_objects_v2(Bucket="altastata-bucket")` → **51 real encrypted objects** (PDFs / MP4s / etc.), proving the data path flows boto3 → S3 gateway → `AltaStataFileSystem` (same instance the Python API holds via `AccountRegistry`).
  - Cache: a second `s3_credentials()` issued zero additional PUTs.
  - `install_aws_env()` populated all four `AWS_*` env vars.

## Known follow-ups (intentionally not in this PR)

- `S3Controller`'s existing `/app/data/.userdata.json` persistence write fails with ERROR-level log inside the jupyter container (no `/app/data` mount). In-memory state still works (HTTP 200 returned). Will mount the dir or make the path configurable in a follow-up.
- Unified `UserAdminRegistry` in `mycloud` (per [`ALTASTATA_SERVICES_UBER_DESIGN.md`](https://github.com/SergeVil/mycloud/blob/openshift/ALTASTATA_SERVICES_UBER_DESIGN.md) §3.1) will retire the duplicate admin PUT surface between gRPC and S3 and close the `validatePassword` mutation gap on the shared `AltaStataFileSystem`.
