### PR TITLE
jupyter compose: persist S3 gateway user data to mounted volume

### DIFF
--- a/containers/jupyter/docker-compose.yml
+++ b/containers/jupyter/docker-compose.yml
@@ -45,6 +45,15 @@ services:
       # bind only gRPC + py4j (the JVM still listens on 9876 but with no S3
       # routes registered).
       - ALTASTATA_SERVICES_S3GATEWAY_ENABLED=${ALTASTATA_SERVICES_S3GATEWAY_ENABLED:-true}
+      # S3Controller persists its userDataMap (per-user access/secret keys
+      # + encrypted user_properties + encrypted private-key PEM) to JSON so
+      # it survives container restarts. Default path /app/data/.userdata.json
+      # does not exist in this image; redirect to the existing jupyter-data
+      # named volume mounted at /home/jovyan/work so persistence Just Works
+      # without adding a new bind mount. The file does NOT contain plaintext
+      # passwords or decrypted material — all sensitive bytes are still
+      # encrypted by the user password (see S3Controller.getConfigurableFilePath).
+      - ALTASTATA_USERDATA_FILE=${ALTASTATA_USERDATA_FILE:-/home/jovyan/work/altastata-userdata.json}
     networks:
       - altastata-network
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Tiny config-only follow-up to #99: stop the S3 gateway from logging `Failed to save user data to file: /app/data/.userdata.json` on every admin PUT inside the Jupyter container.

The bundled S3 gateway (`S3Controller`) persists its `userDataMap` (per-user access/secret keys + encrypted user properties + encrypted private-key PEM) to JSON so the access-key → user mapping survives `docker restart`. The hard-coded default `/app/data/.userdata.json` does not exist in `jupyter-datascience` images, so without an override `S3Controller` logs an `ERROR` on every PUT (in-memory state still worked, but was lost on restart).

This PR redirects persistence to `/home/jovyan/work/altastata-userdata.json` — already mounted via the existing `jupyter-data` named volume — so persistence Just Works without adding a new bind mount.

Diff is **9 lines, one env var + comment**:

```yaml
- ALTASTATA_USERDATA_FILE=${ALTASTATA_USERDATA_FILE:-/home/jovyan/work/altastata-userdata.json}
```

## Security note

The persisted file does **NOT** contain plaintext passwords or any decrypted material:

| field | content |
|---|---|
| `accessKey` | random `ak-temp-<userName>-<8 hex>` — opaque token |
| `secretKey` | random `sk-temp-<userName>-<32 hex>` — opaque token |
| `userProperties` | encrypted (AES, key derived from user password) |
| `privateKeyEncrypted` | encrypted (PEM, key derived from user password) |

After a restart the keys load from disk, but the in-memory `S3Service` is `null` until the user re-supplies the password via `s3_credentials()` (which internally calls `/setPassword`). Without the password the persisted bytes are useless. This is the same security posture as before; we just stop spamming ERROR logs.

## Test plan

End-to-end on freshly built `altastata/jupyter-datascience-arm64:2026e_latest`:

- [x] Container boots; JVM picks up `ALTASTATA_USERDATA_FILE` via `/proc/$PID/environ`
- [x] `AltaStataFunctions.from_account_dir(...).s3_credentials()` succeeds (3 admin PUTs against `:9876`)
- [x] `boto3_s3().list_buckets()` → HTTP 200, 1 bucket
- [x] `boto3_s3().list_objects_v2("altastata-bucket")` → HTTP 200, KeyCount=51
- [x] `/home/jovyan/work/altastata-userdata.json` exists (1891 bytes), no `Failed to save user data` ERROR in JVM log
- [x] `docker restart altastata-jupyter` → file persists, **same accessKey** (`ak-temp-user-d46de252`) loaded from disk
- [x] After restart, `s3_credentials()` re-bootstraps (sends `?password=` for idempotency) and unlocks `S3Service`; `list_buckets` / `list_objects_v2` succeed again
- [x] Inspected JSON contents: no `password` key, no plaintext material
