### PR TITLE
Migrate gRPC transport to AuthService.LoginV2 (migration step 8).

### DIFF
--- a/README-developer.md
+++ b/README-developer.md
@@ -74,6 +74,14 @@ If you prefer to drive each build yourself:
    `ALTASTATA_WEB_UI_DIR=` (empty) before running to disable the UI and
    keep gRPC-only routing for legacy testing.
 
+### gRPC transport (`transport="grpc"`)
+
+`AltaStataGrpcClient.from_account_dir` authenticates via `AuthService.LoginV2`
+with `user_account_directory` (account folder on the same host as the gateway).
+`from_credentials` uses the `upload` form (`user_properties` + private key
+bytes). Legacy `SetUserProperties` / `SetPrivateKey` bootstrap is not used on
+the gRPC path. See `mycloud/altastata-grpc/CONSOLE_ACCOUNT_SETUP_DESIGN.md` §2.
+
 ### Logging Configuration
 - To customize logging, copy and modify the logback configuration:
   ```bash

--- a/altastata/grpc_client.py
+++ b/altastata/grpc_client.py
@@ -55,11 +55,14 @@ class AltaStataGrpcClient:
     The legacy ``local-<userName>`` / ``access-<accessKey>`` token paths are
     no longer accepted by the gateway and are not produced by this client.
 
-    First-contact bootstrap (when the gateway has never seen this user in
-    this JVM) is still required: the gateway needs the user's properties
-    and encrypted private key in memory before ``Login`` can validate the
-    password. ``from_account_dir`` / ``from_credentials`` perform that
-    bootstrap once and then immediately call ``Login``.
+    First-contact authentication uses ``AuthService.LoginV2``:
+
+    - ``from_account_dir`` sends ``user_account_directory`` (co-located gateway).
+    - ``from_credentials`` sends ``upload`` with ``user_properties`` + private key
+      file bytes (remote / in-memory bootstrap).
+
+    Legacy ``SetUserProperties`` / ``SetPrivateKey`` bootstrap is no longer used
+    by this client.
     """
 
     def __init__(
@@ -69,6 +72,8 @@ class AltaStataGrpcClient:
         bearer_token: str,
         user_name: Optional[str] = None,
         client_hint: Optional[str] = None,
+        account_dir_path: Optional[str] = None,
+        login_upload: Optional[Tuple[str, Dict[str, bytes]]] = None,
     ):
         if not bearer_token:
             raise ValueError("bearer_token is required (use AuthService.Login or pass an existing sess-<token>)")
@@ -81,6 +86,8 @@ class AltaStataGrpcClient:
         # and evicts only this instance's own prior session, not someone
         # else's session for the same user.
         self._client_hint = client_hint or _default_client_hint()
+        self._account_dir_path = account_dir_path
+        self._login_upload = login_upload
         self._metadata: List[Tuple[str, str]] = [("authorization", f"Bearer {self._token}")]
         self._channel = self._create_channel(endpoint)
 
@@ -135,11 +142,9 @@ class AltaStataGrpcClient:
         """
         Create a gRPC client from an AltaStata account directory.
 
-        Reads ``*.user.properties`` + ``private.key`` from disk, ships them
-        to the gateway via the bootstrap RPCs, and then calls
-        ``AuthService.Login`` to obtain a per-process session token. All
-        subsequent RPCs on the returned client are authenticated with that
-        ``sess-<token>``.
+        Calls ``AuthService.LoginV2`` with ``user_account_directory`` so the
+        gateway reads ``*user.properties`` and private key material from disk
+        (RSA ``private.key``, PQC private keys, HPCS ``hpcs-privkey.blob``, etc.).
 
         ``client_hint`` defaults to a freshly minted, per-instance UUID
         prefixed with ``altastata-python-package/`` so two clients in the
@@ -148,22 +153,15 @@ class AltaStataGrpcClient:
         deliberately want a different instance to *replace* a prior one.
         """
         if password is None:
-            raise ValueError("password is required for AuthService.Login")
+            raise ValueError("password is required for AuthService.LoginV2")
 
         account_dir = os.path.abspath(account_dir_path)
         if not os.path.isdir(account_dir):
             raise FileNotFoundError(f"Account directory not found: {account_dir}")
 
         user_properties_path = _find_user_properties_file(account_dir)
-        private_key_path = os.path.join(account_dir, "private.key")
-        if not os.path.exists(private_key_path):
-            raise FileNotFoundError(f"private.key not found in account directory: {account_dir}")
-
         with open(user_properties_path, "r", encoding="utf-8") as f:
             user_properties = f.read()
-        with open(private_key_path, "r", encoding="utf-8") as f:
-            private_key = f.read()
-
         resolved_user_name = user_name or _infer_user_name(account_dir, user_properties_path)
 
         started_process = None
@@ -175,13 +173,11 @@ class AltaStataGrpcClient:
             _wait_for_port(endpoint.host, endpoint.port, timeout_s=start_timeout_s)
 
         effective_hint = client_hint or _default_client_hint()
-        token = _bootstrap_and_login(
+        token = _login_v2(
             endpoint=endpoint,
-            user_name=resolved_user_name,
-            user_properties=user_properties,
-            private_key_encrypted=private_key,
             password=password,
             client_hint=effective_hint,
+            user_account_directory=account_dir,
         )
 
         client = cls(
@@ -189,6 +185,7 @@ class AltaStataGrpcClient:
             bearer_token=token,
             user_name=resolved_user_name,
             client_hint=effective_hint,
+            account_dir_path=account_dir,
         )
         client._server_process = started_process
         return client
@@ -215,9 +212,10 @@ class AltaStataGrpcClient:
         omitted, a fresh per-instance UUID is generated automatically.
         """
         if password is None:
-            raise ValueError("password is required for AuthService.Login")
+            raise ValueError("password is required for AuthService.LoginV2")
 
         resolved_user_name = user_name or _infer_user_name_from_properties_text(user_properties)
+        account_files = _account_files_from_private_key(private_key_encrypted)
 
         started_process = None
         if not _is_port_open(endpoint.host, endpoint.port) and auto_start_server:
@@ -228,13 +226,12 @@ class AltaStataGrpcClient:
             _wait_for_port(endpoint.host, endpoint.port, timeout_s=start_timeout_s)
 
         effective_hint = client_hint or _default_client_hint()
-        token = _bootstrap_and_login(
+        token = _login_v2(
             endpoint=endpoint,
-            user_name=resolved_user_name,
-            user_properties=user_properties,
-            private_key_encrypted=private_key_encrypted,
             password=password,
             client_hint=effective_hint,
+            user_properties=user_properties,
+            account_files=account_files,
         )
 
         client = cls(
@@ -242,6 +239,7 @@ class AltaStataGrpcClient:
             bearer_token=token,
             user_name=resolved_user_name,
             client_hint=effective_hint,
+            login_upload=(user_properties, account_files),
         )
         client._server_process = started_process
         return client
@@ -515,11 +513,8 @@ class AltaStataGrpcClient:
     def set_password(self, account_password: str):
         """
         Re-authenticate this client by logging out the current session (if any)
-        and calling ``AuthService.Login`` again.
-
-        Mirrors the legacy Py4J behaviour where ``setPassword`` unlocks the
-        account; over gRPC this is now a Logout-then-Login. The previous
-        ``SetPasswordForUser`` bootstrap RPC has been removed.
+        and calling ``AuthService.LoginV2`` again (or legacy ``Login`` when no
+        account material was stored at construction).
         """
         if not self._user_name:
             raise RuntimeError(
@@ -539,15 +534,39 @@ class AltaStataGrpcClient:
         except Exception:
             pass
 
-        resp = self._auth_stub.Login(
-            self._auth_pb2.LoginRequest(
-                user_name=self._user_name,
-                account_password=account_password,
+        if self._account_dir_path:
+            token = _login_v2(
+                endpoint=self.endpoint,
+                password=account_password,
                 client_hint=self._client_hint,
-            ),
-            timeout=30.0,
-        )
-        self._token = resp.session_token
+                user_account_directory=self._account_dir_path,
+            )
+        elif self._login_upload is not None:
+            user_properties, account_files = self._login_upload
+            token = _login_v2(
+                endpoint=self.endpoint,
+                password=account_password,
+                client_hint=self._client_hint,
+                user_properties=user_properties,
+                account_files=account_files,
+            )
+        elif self._user_name:
+            resp = self._auth_stub.Login(
+                self._auth_pb2.LoginRequest(
+                    user_name=self._user_name,
+                    account_password=account_password,
+                    client_hint=self._client_hint,
+                ),
+                timeout=30.0,
+            )
+            token = resp.session_token
+        else:
+            raise RuntimeError(
+                "set_password requires account_dir_path or login upload material; "
+                "reconstruct the client via from_account_dir / from_credentials."
+            )
+
+        self._token = token
         self._metadata = [("authorization", f"Bearer {self._token}")]
         return True
 
@@ -706,6 +725,67 @@ def _infer_user_name(account_dir: str, user_properties_path: str) -> str:
     raise ValueError("Unable to infer user name from account directory")
 
 
+def _account_files_from_private_key(private_key_encrypted: str) -> Dict[str, bytes]:
+    """Map legacy ``private_key_encrypted`` PEM text to LoginV2 upload files."""
+    files: Dict[str, bytes] = {}
+    if private_key_encrypted:
+        files["private.key"] = private_key_encrypted.encode("utf-8")
+    return files
+
+
+def _login_v2(
+    endpoint: GrpcEndpoint,
+    password: str,
+    client_hint: str,
+    *,
+    user_account_directory: Optional[str] = None,
+    user_properties: Optional[str] = None,
+    account_files: Optional[Dict[str, bytes]] = None,
+) -> str:
+    """
+    Authenticate via ``AuthService.LoginV2``.
+
+    Exactly one of ``user_account_directory`` or ``user_properties`` must be set.
+    Returns the issued ``sess-<token>``.
+    """
+    if user_account_directory:
+        if user_properties is not None or account_files is not None:
+            raise ValueError("user_account_directory cannot be combined with upload fields")
+    elif user_properties is None:
+        raise ValueError("user_account_directory or user_properties is required")
+    else:
+        if not user_properties.strip():
+            raise ValueError("user_properties is required for LoginV2 upload")
+
+    try:
+        from .v1 import auth_pb2, auth_pb2_grpc
+    except Exception as exc:
+        raise ImportError(
+            "gRPC stubs are missing. Run: python scripts/generate_grpc_stubs.py"
+        ) from exc
+
+    channel = AltaStataGrpcClient._create_channel(endpoint)
+    try:
+        auth = auth_pb2_grpc.AuthServiceStub(channel)
+        req = auth_pb2.LoginV2Request(
+            client_hint=client_hint,
+            password=password,
+        )
+        if user_account_directory is not None:
+            req.user_account_directory = user_account_directory
+        else:
+            upload = auth_pb2.LoginV2Upload(user_properties=user_properties)
+            if account_files:
+                for name, data in account_files.items():
+                    upload.account_files[name] = data
+            req.upload.CopyFrom(upload)
+
+        resp = auth.LoginV2(req, timeout=30.0)
+        return resp.session_token
+    finally:
+        channel.close()
+
+
 def _bootstrap_and_login(
     endpoint: GrpcEndpoint,
     user_name: str,
@@ -714,74 +794,15 @@ def _bootstrap_and_login(
     password: str,
     client_hint: str,
 ) -> str:
-    """
-    Install ``user_properties`` + ``private_key_encrypted`` for ``user_name``
-    in the gateway's in-memory registry (idempotent — safe to call repeatedly
-    for the same user) and then authenticate via ``AuthService.Login``.
-
-    Returns the issued ``sess-<token>``.
-
-    The bootstrap RPCs (``SetUserProperties`` / ``SetPrivateKey``) are still
-    auth-bypassed on the server because the user has no session yet at this
-    point. ``Login`` is the first authenticated call: a wrong password is
-    rejected here without corrupting any other live session for the same user.
-
-    HPCS / HSM-backed accounts pass ``private_key_encrypted=""`` because the
-    private key material lives in the HSM rather than as a local PEM. In that
-    case ``SetPrivateKey`` is skipped entirely — the gateway sources the key
-    material server-side from ``user_properties`` (e.g. ``hpcs-priv-key-blob-path``
-    + ``hpcs-yaml-path``) and the EP11 client.
-    """
-    try:
-        from .v1 import auth_pb2, auth_pb2_grpc
-        from .v1 import users_pb2, users_pb2_grpc
-    except Exception as exc:
-        raise ImportError(
-            "gRPC stubs are missing. Run: python scripts/generate_grpc_stubs.py"
-        ) from exc
-
-    channel = AltaStataGrpcClient._create_channel(endpoint)
-    try:
-        users = users_pb2_grpc.UsersServiceStub(channel)
-        # The gateway returns ALREADY_EXISTS for SetUserProperties /
-        # SetPrivateKey when this userName already has a live
-        # AltaStataFileSystem (another browser tab / Python client of the
-        # same user is already logged in). The right reaction is to skip
-        # straight to AuthService.Login — the whole point of #186 was to
-        # stop a second client from re-installing properties / private
-        # key over a running session. See SESSION_AND_EVENTS_DESIGN.md
-        # §8.1.
-        try:
-            users.SetUserProperties(users_pb2.SetUserPropertiesRequest(
-                user_name=user_name,
-                user_properties=user_properties,
-            ))
-        except grpc.RpcError as exc:
-            if exc.code() != grpc.StatusCode.ALREADY_EXISTS:
-                raise
-        # HPCS / HSM-backed accounts have no PEM to send; the server's
-        # SetPrivateKey validator rejects an empty private_key_encrypted with
-        # INVALID_ARGUMENT, so skip the call entirely in that case. The
-        # gateway derives the key material from user_properties on first use.
-        if private_key_encrypted:
-            try:
-                users.SetPrivateKey(users_pb2.SetPrivateKeyRequest(
-                    user_name=user_name,
-                    private_key_encrypted=private_key_encrypted,
-                ))
-            except grpc.RpcError as exc:
-                if exc.code() != grpc.StatusCode.ALREADY_EXISTS:
-                    raise
-
-        auth = auth_pb2_grpc.AuthServiceStub(channel)
-        resp = auth.Login(auth_pb2.LoginRequest(
-            user_name=user_name,
-            account_password=password,
-            client_hint=client_hint,
-        ), timeout=30.0)
-        return resp.session_token
-    finally:
-        channel.close()
+    """Deprecated alias — use :func:`_login_v2`."""
+    del user_name
+    return _login_v2(
+        endpoint=endpoint,
+        password=password,
+        client_hint=client_hint,
+        user_properties=user_properties,
+        account_files=_account_files_from_private_key(private_key_encrypted),
+    )
 
 
 def _infer_user_name_from_properties_text(user_properties: str) -> str:

--- a/altastata/v1/auth_pb2.py
+++ b/altastata/v1/auth_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x17\x61ltastata/v1/auth.proto\x12\x0c\x61ltastata.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"P\n\x0cLoginRequest\x12\x11\n\tuser_name\x18\x01 \x01(\t\x12\x18\n\x10\x61\x63\x63ount_password\x18\x02 \x01(\t\x12\x13\n\x0b\x63lient_hint\x18\x03 \x01(\t\"j\n\rLoginResponse\x12\x15\n\rsession_token\x18\x01 \x01(\t\x12.\n\nexpires_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x12\n\naccess_key\x18\x03 \x01(\t\"\x0f\n\rLogoutRequest\"\x10\n\x0eLogoutResponse\"\x10\n\x0eRefreshRequest\"A\n\x0fRefreshResponse\x12.\n\nexpires_at\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp2\xdc\x01\n\x0b\x41uthService\x12@\n\x05Login\x12\x1a.altastata.v1.LoginRequest\x1a\x1b.altastata.v1.LoginResponse\x12\x43\n\x06Logout\x12\x1b.altastata.v1.LogoutRequest\x1a\x1c.altastata.v1.LogoutResponse\x12\x46\n\x07Refresh\x12\x1c.altastata.v1.RefreshRequest\x1a\x1d.altastata.v1.RefreshResponseB\'\n\x18\x63om.altastata.grpc.protoB\tAuthProtoP\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x17\x61ltastata/v1/auth.proto\x12\x0c\x61ltastata.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"P\n\x0cLoginRequest\x12\x11\n\tuser_name\x18\x01 \x01(\t\x12\x18\n\x10\x61\x63\x63ount_password\x18\x02 \x01(\t\x12\x13\n\x0b\x63lient_hint\x18\x03 \x01(\t\"j\n\rLoginResponse\x12\x15\n\rsession_token\x18\x01 \x01(\t\x12.\n\nexpires_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x12\n\naccess_key\x18\x03 \x01(\t\"\x0f\n\rLogoutRequest\"\x10\n\x0eLogoutResponse\"\x10\n\x0eRefreshRequest\"A\n\x0fRefreshResponse\x12.\n\nexpires_at\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"\x9a\x01\n\x0eLoginV2Request\x12\x13\n\x0b\x63lient_hint\x18\x01 \x01(\t\x12\x10\n\x08password\x18\x02 \x01(\t\x12-\n\x06upload\x18\x03 \x01(\x0b\x32\x1b.altastata.v1.LoginV2UploadH\x00\x12 \n\x16user_account_directory\x18\x04 \x01(\tH\x00\x42\x10\n\x0e\x61\x63\x63ount_source\"\xa3\x01\n\rLoginV2Upload\x12\x17\n\x0fuser_properties\x18\x01 \x01(\t\x12\x44\n\raccount_files\x18\x02 \x03(\x0b\x32-.altastata.v1.LoginV2Upload.AccountFilesEntry\x1a\x33\n\x11\x41\x63\x63ountFilesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x0c:\x02\x38\x01\"X\n\x0fLoginV2Response\x12\x15\n\rsession_token\x18\x01 \x01(\t\x12.\n\nexpires_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp2\xa4\x02\n\x0b\x41uthService\x12@\n\x05Login\x12\x1a.altastata.v1.LoginRequest\x1a\x1b.altastata.v1.LoginResponse\x12\x46\n\x07LoginV2\x12\x1c.altastata.v1.LoginV2Request\x1a\x1d.altastata.v1.LoginV2Response\x12\x43\n\x06Logout\x12\x1b.altastata.v1.LogoutRequest\x1a\x1c.altastata.v1.LogoutResponse\x12\x46\n\x07Refresh\x12\x1c.altastata.v1.RefreshRequest\x1a\x1d.altastata.v1.RefreshResponseB\'\n\x18\x63om.altastata.grpc.protoB\tAuthProtoP\x01\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,6 +33,8 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'altastata.v1.auth_pb2', _gl
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\030com.altastata.grpc.protoB\tAuthProtoP\001'
+  _globals['_LOGINV2UPLOAD_ACCOUNTFILESENTRY']._loaded_options = None
+  _globals['_LOGINV2UPLOAD_ACCOUNTFILESENTRY']._serialized_options = b'8\001'
   _globals['_LOGINREQUEST']._serialized_start=74
   _globals['_LOGINREQUEST']._serialized_end=154
   _globals['_LOGINRESPONSE']._serialized_start=156
@@ -45,6 +47,14 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_REFRESHREQUEST']._serialized_end=315
   _globals['_REFRESHRESPONSE']._serialized_start=317
   _globals['_REFRESHRESPONSE']._serialized_end=382
-  _globals['_AUTHSERVICE']._serialized_start=385
-  _globals['_AUTHSERVICE']._serialized_end=605
+  _globals['_LOGINV2REQUEST']._serialized_start=385
+  _globals['_LOGINV2REQUEST']._serialized_end=539
+  _globals['_LOGINV2UPLOAD']._serialized_start=542
+  _globals['_LOGINV2UPLOAD']._serialized_end=705
+  _globals['_LOGINV2UPLOAD_ACCOUNTFILESENTRY']._serialized_start=654
+  _globals['_LOGINV2UPLOAD_ACCOUNTFILESENTRY']._serialized_end=705
+  _globals['_LOGINV2RESPONSE']._serialized_start=707
+  _globals['_LOGINV2RESPONSE']._serialized_end=795
+  _globals['_AUTHSERVICE']._serialized_start=798
+  _globals['_AUTHSERVICE']._serialized_end=1090
 # @@protoc_insertion_point(module_scope)

--- a/altastata/v1/auth_pb2_grpc.py
+++ b/altastata/v1/auth_pb2_grpc.py
@@ -51,6 +51,11 @@ class AuthServiceStub(object):
                 request_serializer=altastata_dot_v1_dot_auth__pb2.LoginRequest.SerializeToString,
                 response_deserializer=altastata_dot_v1_dot_auth__pb2.LoginResponse.FromString,
                 _registered_method=True)
+        self.LoginV2 = channel.unary_unary(
+                '/altastata.v1.AuthService/LoginV2',
+                request_serializer=altastata_dot_v1_dot_auth__pb2.LoginV2Request.SerializeToString,
+                response_deserializer=altastata_dot_v1_dot_auth__pb2.LoginV2Response.FromString,
+                _registered_method=True)
         self.Logout = channel.unary_unary(
                 '/altastata.v1.AuthService/Logout',
                 request_serializer=altastata_dot_v1_dot_auth__pb2.LogoutRequest.SerializeToString,
@@ -84,6 +89,12 @@ class AuthServiceServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def LoginV2(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
     def Logout(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -103,6 +114,11 @@ def add_AuthServiceServicer_to_server(servicer, server):
                     servicer.Login,
                     request_deserializer=altastata_dot_v1_dot_auth__pb2.LoginRequest.FromString,
                     response_serializer=altastata_dot_v1_dot_auth__pb2.LoginResponse.SerializeToString,
+            ),
+            'LoginV2': grpc.unary_unary_rpc_method_handler(
+                    servicer.LoginV2,
+                    request_deserializer=altastata_dot_v1_dot_auth__pb2.LoginV2Request.FromString,
+                    response_serializer=altastata_dot_v1_dot_auth__pb2.LoginV2Response.SerializeToString,
             ),
             'Logout': grpc.unary_unary_rpc_method_handler(
                     servicer.Logout,
@@ -154,6 +170,33 @@ class AuthService(object):
             '/altastata.v1.AuthService/Login',
             altastata_dot_v1_dot_auth__pb2.LoginRequest.SerializeToString,
             altastata_dot_v1_dot_auth__pb2.LoginResponse.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def LoginV2(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/altastata.v1.AuthService/LoginV2',
+            altastata_dot_v1_dot_auth__pb2.LoginV2Request.SerializeToString,
+            altastata_dot_v1_dot_auth__pb2.LoginV2Response.FromString,
             options,
             channel_credentials,
             insecure,

--- a/proto/altastata/v1/auth.proto
+++ b/proto/altastata/v1/auth.proto
@@ -22,6 +22,7 @@ import "google/protobuf/timestamp.proto";
 // other sessions of the same user are unaffected.
 service AuthService {
   rpc Login(LoginRequest) returns (LoginResponse);
+  rpc LoginV2(LoginV2Request) returns (LoginV2Response);
   rpc Logout(LogoutRequest) returns (LogoutResponse);
   rpc Refresh(RefreshRequest) returns (RefreshResponse);
 }
@@ -53,4 +54,25 @@ message LogoutResponse {}
 message RefreshRequest {}
 message RefreshResponse {
   google.protobuf.Timestamp expires_at = 1;
+}
+
+// Target session entry — see CONSOLE_ACCOUNT_SETUP_DESIGN.md §5.2.
+message LoginV2Request {
+  string client_hint = 1;
+  string password = 2;
+
+  oneof account_source {
+    LoginV2Upload upload = 3;
+    string user_account_directory = 4;
+  }
+}
+
+message LoginV2Upload {
+  string user_properties = 1;
+  map<string, bytes> account_files = 2;
+}
+
+message LoginV2Response {
+  string session_token = 1;
+  google.protobuf.Timestamp expires_at = 2;
 }

--- a/tests/test_grpc_client.py
+++ b/tests/test_grpc_client.py
@@ -117,7 +117,7 @@ class GrpcClientTests(unittest.TestCase):
         self.assertEqual("bob123", _infer_user_name_from_properties_text(props))
 
     @patch("altastata.grpc_client.grpc.insecure_channel")
-    @patch("altastata.grpc_client._bootstrap_and_login")
+    @patch("altastata.grpc_client._login_v2")
     @patch("altastata.grpc_client._wait_for_port")
     @patch("altastata.grpc_client._start_local_grpc_service")
     @patch("altastata.grpc_client._is_port_open")
@@ -126,13 +126,13 @@ class GrpcClientTests(unittest.TestCase):
         mock_is_port_open,
         mock_start_server,
         _mock_wait_for_port,
-        mock_bootstrap_and_login,
+        mock_login_v2,
         mock_insecure_channel,
     ):
         mock_insecure_channel.return_value = object()
         mock_is_port_open.return_value = False
         mock_start_server.return_value = object()
-        mock_bootstrap_and_login.return_value = "sess-test-token"
+        mock_login_v2.return_value = "sess-test-token"
 
         with tempfile.TemporaryDirectory() as td:
             up = os.path.join(td, "altastata-org-bob123.user.properties")
@@ -152,14 +152,14 @@ class GrpcClientTests(unittest.TestCase):
                 grpc_server_working_dir=td,
             )
             mock_start_server.assert_called_once()
-            mock_bootstrap_and_login.assert_called_once()
+            mock_login_v2.assert_called_once()
             self.assertEqual(
                 [("authorization", "Bearer sess-test-token")],
                 client._metadata,
             )
 
     @patch("altastata.grpc_client.grpc.insecure_channel")
-    @patch("altastata.grpc_client._bootstrap_and_login")
+    @patch("altastata.grpc_client._login_v2")
     @patch("altastata.grpc_client._wait_for_port")
     @patch("altastata.grpc_client._start_local_grpc_service")
     @patch("altastata.grpc_client._is_port_open")
@@ -168,13 +168,13 @@ class GrpcClientTests(unittest.TestCase):
         mock_is_port_open,
         mock_start_server,
         _mock_wait_for_port,
-        mock_bootstrap_and_login,
+        mock_login_v2,
         mock_insecure_channel,
     ):
         mock_insecure_channel.return_value = object()
         mock_is_port_open.return_value = False
         mock_start_server.return_value = object()
-        mock_bootstrap_and_login.return_value = "sess-test-token"
+        mock_login_v2.return_value = "sess-test-token"
 
         from altastata.grpc_client import AltaStataGrpcClient, GrpcEndpoint
         AltaStataGrpcClient.from_credentials(
@@ -187,79 +187,101 @@ class GrpcClientTests(unittest.TestCase):
             grpc_server_working_dir="/tmp",
         )
         mock_start_server.assert_called_once()
-        mock_bootstrap_and_login.assert_called_once()
+        mock_login_v2.assert_called_once()
+
+    @patch("altastata.grpc_client.grpc.insecure_channel")
+    @patch("altastata.grpc_client._login_v2")
+    @patch("altastata.grpc_client._wait_for_port")
+    @patch("altastata.grpc_client._start_local_grpc_service")
+    @patch("altastata.grpc_client._is_port_open")
+    def test_from_account_dir_hpcs_without_private_key(
+        self,
+        mock_is_port_open,
+        mock_start_server,
+        _mock_wait_for_port,
+        mock_login_v2,
+        mock_insecure_channel,
+    ):
+        """HPCS accounts have no private.key on disk; LoginV2 directory mode reads the blob."""
+        mock_insecure_channel.return_value = object()
+        mock_is_port_open.return_value = True
+        mock_login_v2.return_value = "sess-hpcs-token"
+
+        with tempfile.TemporaryDirectory() as td:
+            up = os.path.join(td, "altastata-org-serge678.user.properties")
+            with open(up, "w", encoding="utf-8") as f:
+                f.write("myuser=serge678\nkey-protection=HPCS\n")
+
+            from altastata.grpc_client import AltaStataGrpcClient, GrpcEndpoint
+            client = AltaStataGrpcClient.from_account_dir(
+                td,
+                password="",
+                endpoint=GrpcEndpoint(host="127.0.0.1", port=9877, secure=False),
+                auto_start_server=False,
+            )
+            mock_start_server.assert_not_called()
+            mock_login_v2.assert_called_once()
+            _, kwargs = mock_login_v2.call_args
+            self.assertEqual(os.path.abspath(td), kwargs["user_account_directory"])
+            self.assertEqual(
+                [("authorization", "Bearer sess-hpcs-token")],
+                client._metadata,
+            )
 
     @patch("altastata.grpc_client.AltaStataGrpcClient._create_channel")
-    def test_bootstrap_skips_set_private_key_for_hpcs_account(self, mock_create_channel):
-        """HPCS / HSM-backed accounts pass private_key_encrypted="" because the
-        key lives in the HSM. The server's SetPrivateKey validator rejects an
-        empty PEM with INVALID_ARGUMENT, so the client must skip that RPC
-        entirely. SetUserProperties and Login must still run."""
-        users_stub_mock = MagicMock()
+    def test_login_v2_upload_skips_private_key_for_hpcs(self, mock_create_channel):
         auth_stub_mock = MagicMock()
-        auth_stub_mock.Login.return_value = MagicMock(session_token="sess-hpcs-token")
+        auth_stub_mock.LoginV2.return_value = MagicMock(session_token="sess-hpcs-token")
 
-        sys.modules["altastata.v1.users_pb2_grpc"].UsersServiceStub = MagicMock(
-            return_value=users_stub_mock,
-        )
+        auth_pb2 = types.ModuleType("auth_pb2")
+        auth_pb2.LoginV2Request = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+        auth_pb2.LoginV2Upload = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+        sys.modules["altastata.v1.auth_pb2"] = auth_pb2
         sys.modules["altastata.v1.auth_pb2_grpc"].AuthServiceStub = MagicMock(
             return_value=auth_stub_mock,
         )
-        sys.modules["altastata.v1.users_pb2"].SetUserPropertiesRequest = MagicMock()
-        sys.modules["altastata.v1.users_pb2"].SetPrivateKeyRequest = MagicMock()
-        sys.modules["altastata.v1.auth_pb2"].LoginRequest = MagicMock()
 
         mock_create_channel.return_value = MagicMock()
 
-        from altastata.grpc_client import _bootstrap_and_login, GrpcEndpoint
-        token = _bootstrap_and_login(
+        from altastata.grpc_client import _login_v2, GrpcEndpoint
+        token = _login_v2(
             endpoint=GrpcEndpoint(host="127.0.0.1", port=9877, secure=False),
-            user_name="serge678",
-            user_properties="myuser=serge678\nkey-protection=HPCS\n",
-            private_key_encrypted="",
             password="",
             client_hint="hpcs-test",
+            user_properties="myuser=serge678\nkey-protection=HPCS\n",
+            account_files={},
         )
 
         self.assertEqual("sess-hpcs-token", token)
-        users_stub_mock.SetUserProperties.assert_called_once()
-        users_stub_mock.SetPrivateKey.assert_not_called()
-        auth_stub_mock.Login.assert_called_once()
+        auth_stub_mock.LoginV2.assert_called_once()
 
     @patch("altastata.grpc_client.AltaStataGrpcClient._create_channel")
-    def test_bootstrap_calls_set_private_key_for_rsa_account(self, mock_create_channel):
-        """Regression guard: password-based / RSA accounts pass a real
-        encrypted PEM and SetPrivateKey must still be called for them."""
-        users_stub_mock = MagicMock()
+    def test_login_v2_upload_includes_private_key_for_rsa(self, mock_create_channel):
         auth_stub_mock = MagicMock()
-        auth_stub_mock.Login.return_value = MagicMock(session_token="sess-rsa-token")
+        auth_stub_mock.LoginV2.return_value = MagicMock(session_token="sess-rsa-token")
 
-        sys.modules["altastata.v1.users_pb2_grpc"].UsersServiceStub = MagicMock(
-            return_value=users_stub_mock,
-        )
+        auth_pb2 = types.ModuleType("auth_pb2")
+        auth_pb2.LoginV2Request = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+        auth_pb2.LoginV2Upload = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+        sys.modules["altastata.v1.auth_pb2"] = auth_pb2
         sys.modules["altastata.v1.auth_pb2_grpc"].AuthServiceStub = MagicMock(
             return_value=auth_stub_mock,
         )
-        sys.modules["altastata.v1.users_pb2"].SetUserPropertiesRequest = MagicMock()
-        sys.modules["altastata.v1.users_pb2"].SetPrivateKeyRequest = MagicMock()
-        sys.modules["altastata.v1.auth_pb2"].LoginRequest = MagicMock()
 
         mock_create_channel.return_value = MagicMock()
 
-        from altastata.grpc_client import _bootstrap_and_login, GrpcEndpoint
-        token = _bootstrap_and_login(
+        from altastata.grpc_client import _login_v2, GrpcEndpoint
+        pem = "-----BEGIN RSA PRIVATE KEY-----\n...\n"
+        token = _login_v2(
             endpoint=GrpcEndpoint(host="127.0.0.1", port=9877, secure=False),
-            user_name="bob123",
-            user_properties="myuser=bob123\n",
-            private_key_encrypted="-----BEGIN RSA PRIVATE KEY-----\n...\n",
             password="123",
             client_hint="rsa-test",
+            user_properties="myuser=bob123\n",
+            account_files={"private.key": pem.encode("utf-8")},
         )
 
         self.assertEqual("sess-rsa-token", token)
-        users_stub_mock.SetUserProperties.assert_called_once()
-        users_stub_mock.SetPrivateKey.assert_called_once()
-        auth_stub_mock.Login.assert_called_once()
+        auth_stub_mock.LoginV2.assert_called_once()
 
     @patch("altastata.grpc_client.subprocess.Popen")
     @patch("altastata.grpc_client._find_bundled_grpc_uber_jar")


### PR DESCRIPTION
from_account_dir uses user_account_directory; from_credentials uses upload. HPCS accounts no longer require private.key on disk for directory login.