### PR TITLE
chore(release): altastata 0.1.43

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='altastata',
-    version='0.1.42',
+    version='0.1.43',
     author='Serge Vilvovsky',
     author_email='serge.vilvovsky@altastata.com',
     description='A Python package for Altastata data processing and machine learning integration',


### PR DESCRIPTION
## Summary
- Bump PyPI version 0.1.42 to 0.1.43
- Bundled altastata-services-1.0.0-uber.jar rebuilt from mycloud openshift @ 9a7e3e42 (legacy auth removal, GREP11 HPCS setup, HPCS hardening #213/#214)
- Jupyter/RAG Docker image tags unchanged (2026f_latest / 2026j_latest)

## Build / publish (after merge)
```bash
bash scripts/build-bundled-artifacts.sh   # or SKIP_UI=1 if console unchanged
python -m build
twine check dist/*
twine upload dist/*
```

## Test plan
- [x] build-bundled-artifacts.sh (SKIP_UI=1)
- [x] pytest tests/ — 43 passed
- [x] python -m build + twine check — PASSED
- [ ] pip install wheel smoke test against a real account
