### PR TITLE
Harden JVM memory defaults and refresh Python package README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,254 +1,289 @@
 # Altastata Python Package
 
-A powerful Python package for secure, encrypted cloud storage with seamless integration for data processing, AI, machine learning, and RAG applications.
-
-## Installation
+Secure, encrypted cloud storage for Python — with **fsspec**, **PyTorch/TensorFlow**, **LangChain**, **Databricks**, **Snowflake**, **boto3/S3**, **gRPC**, and a bundled **Web UI** (AltaStata Console).
 
 ```bash
 pip install altastata
 ```
 
-## Features
+## What you get
 
-- **fsspec filesystem interface** - Use standard Python file operations with encrypted cloud storage
-- **S3-compatible API** - Drive boto3 / `aws` CLI / `s3fs` / pyarrow against the bundled S3 gateway with one helper call
-- **Real-time Event Notifications** - Listen for file share, delete, and create events
-- **LangChain Integration** - Native support for document loaders and vector stores
-- **PyTorch & TensorFlow Support** - Custom datasets for machine learning workflows
-- **Multi-cloud Support** - Works with AWS, Azure, GCP, and more
-- **End-to-end Encryption** - AES-256 encryption with zero-trust architecture
+| Capability | How |
+|------------|-----|
+| Encrypted files in S3, Azure, IBM COS, etc. | `AltaStataFunctions` |
+| Standard Python file APIs | `fsspec` (`create_filesystem`) |
+| ML datasets | `AltaStataPyTorchDataset`, `AltaStataTensorFlowDataset` |
+| **LangChain** / RAG document loading | fsspec + `DirectoryLoader` / `TextLoader` |
+| **Databricks** / Apache Spark | AltaStata Hadoop FS (`altastata-hadoop` JAR) |
+| **Snowflake** external stages | S3 Gateway (port **9876**) or Snowpark Python + fsspec |
+| S3 tools (boto3, aws CLI, s3fs) | S3-compatible API on port **9876** |
+| gRPC API (Python `transport="grpc"`, JS clients) | `altastata-services` JVM on port **9877** |
+| Real-time share/delete events | gRPC `EventsService`, Py4J callback, or Web UI |
+| **Web UI** — Finder-style file manager in the browser | http://127.0.0.1:9877 (same JVM as gRPC) |
 
-## Quick Start
+---
+
+## Configure your account
+
+Two equivalent ways to connect from Python:
+
+### 1. Account folder on disk (typical)
+
+Each user keeps a directory under `~/.altastata/accounts/<display-name>/`:
+
+```
+amazon.rsa.bob123/
+  altastata-myorg-bob123.user.properties   # from your admin
+  private.key                              # RSA (password-encrypted PEM)
+  public.key
+```
+
+| Account type | Key files | Password |
+|--------------|-----------|----------|
+| **RSA** | `private.key`, `public.key` | Yes |
+| **PQC** | `kyber_private.key`, `dilithium_private.key`, … | Yes |
+| **HPCS** | `hpcs-privkey.blob`, `public.key`, `hpcs.marker` | No |
+| **HSM** | `*user.properties` only | No |
 
 ```python
-from altastata import AltaStataFunctions, AltaStataPyTorchDataset, AltaStataTensorFlowDataset
-from altastata.altastata_tensorflow_dataset import register_altastata_functions_for_tensorflow
-from altastata.altastata_pytorch_dataset import register_altastata_functions_for_pytorch
+from altastata import AltaStataFunctions
 
-# Configuration parameters
+f = AltaStataFunctions.from_account_dir(
+    "/path/to/.altastata/accounts/amazon.rsa.bob123",
+    transport="grpc",
+    password="your_password",
+)
+```
+
+### 2. Inline credentials (`user_properties` + `private_key`)
+
+Pass the same text you would have in files — useful for notebooks, secrets managers, or CI:
+
+```python
+from altastata import AltaStataFunctions
+
 user_properties = """#My Properties
 #Sun Jan 05 12:10:23 EST 2025
 AWSSecretKey=*****
 AWSAccessKeyId=*****
 myuser=bob123
 accounttype=amazon-s3-secure
-................................................................
-region=us-east-1"""
+acccontainer-prefix=altastata-myorg-
+region=us-east-1
+metadata-encryption=RSA"""
 
 private_key = """-----BEGIN RSA PRIVATE KEY-----
 Proc-Type: 4,ENCRYPTED
 DEK-Info: DES-EDE3,F26EBECE6DDAEC52
 
-poe21ejZGZQ0GOe+EJjDdJpNvJcq/Yig9aYXY2rCGyxXLGVFeYJFg7z6gMCjIpSd
-................................................................
-wV5BUmp5CEmbeB4r/+BlFttRZBLBXT1sq80YyQIVLumq0Livao9mOg==
+... encrypted PEM body ...
 -----END RSA PRIVATE KEY-----"""
 
-# Create an instance of AltaStataFunctions
 altastata_functions = AltaStataFunctions.from_credentials(user_properties, private_key)
 altastata_functions.set_password("my_password")
+
+# Or with gRPC transport:
+altastata_functions = AltaStataFunctions.from_credentials(
+    user_properties,
+    private_key,
+    transport="grpc",
+    password="my_password",
+)
 ```
 
-### gRPC transport (recommended for Python + browser integration)
+Your org admin creates `*user.properties` after you send them `public.key` (RSA/PQC/HPCS).
+
+---
+
+## Quick start (gRPC — recommended)
+
+`transport="grpc"` auto-starts the bundled Java gateway (Web UI + gRPC + S3).
 
 ```python
 from altastata import AltaStataFunctions
 
+# RSA / PQC
 f = AltaStataFunctions.from_account_dir(
-    "/path/to/account",
+    "/path/to/.altastata/accounts/amazon.rsa.bob123",
     transport="grpc",
-    password="123",
+    password="your_password",
 )
+
+# HPCS / HSM — empty password
+f = AltaStataFunctions.from_account_dir(
+    "/path/to/.altastata/accounts/amazon.rsa.hpcs.myuser",
+    transport="grpc",
+    password="",
+)
+
+print(f.list_cloud_versions("Public/", True))
 ```
 
-`transport="grpc"` auto-starts `altastata-grpc` when needed.
+### Ports
 
-To run the gRPC server explicitly (for browser JS or local testing), use either:
+One bundled Java process (`altastata-grpc-server` / `altastata-services`) listens on:
+
+| Port | Service |
+|------|---------|
+| **9877** | gRPC (file ops, auth, events) + Web UI static files |
+| **9876** | S3-compatible REST API |
+| **25333** | Py4J (legacy in-process bridge to Python) |
+
+### HPCS in Docker / Jupyter
+
+Mount a populated `grep11client.yaml` (e.g. `/etc/ep11client/grep11client.yaml`) and `hpcs-privkey.blob`. See [`containers/jupyter/README-Docker.md`](containers/jupyter/README-Docker.md).
+
+---
+
+## Legacy Py4J transport (default)
+
+```python
+from altastata import AltaStataFunctions
+
+f = AltaStataFunctions.from_account_dir("/path/to/account")
+f.set_password("your_password")
+```
+
+---
+
+## fsspec
+
+```python
+from altastata import AltaStataFunctions
+from altastata.fsspec import create_filesystem
+
+f = AltaStataFunctions.from_account_dir("/path/to/account", transport="grpc", password="secret")
+fs = create_filesystem(f, "my_account")
+
+with fs.open("Public/readme.txt", "r") as fh:
+    print(fh.read())
+```
+
+Works with pandas, dask, and other fsspec consumers.
+
+---
+
+## LangChain, Databricks, Snowflake
+
+### LangChain / RAG
+
+Load encrypted documents without copying them to local disk:
+
+```python
+from altastata import AltaStataFunctions
+from altastata.fsspec import create_filesystem
+from langchain_core.documents import Document
+
+f = AltaStataFunctions.from_account_dir("/path/to/account", transport="grpc", password="secret")
+fs = create_filesystem(f, "my_account")
+
+with fs.open("Public/docs/policy.txt", "r") as fh:
+    docs = [Document(page_content=fh.read(), metadata={"source": "Public/docs/policy.txt"})]
+```
+
+`TextLoader`, `DirectoryLoader`, and other LangChain loaders work via the `altastata://` fsspec protocol once the filesystem is registered — see [`examples/fsspec-example/`](examples/fsspec-example/) and full RAG pipelines in [`examples/rag-example/`](examples/rag-example/).
+
+### Databricks / Apache Spark
+
+Use the AltaStata Hadoop filesystem implementation so Spark jobs read encrypted paths on cluster storage (`altastata://…` or configured Hadoop URI). Deploy the `altastata-hadoop` shadow JAR on Databricks / Spark clusters.
+
+### Snowflake
+
+- **External stage via S3:** point Snowflake at the bundled S3 Gateway (`http://host:9876`) as an S3-compatible endpoint for encrypted objects in your backing bucket.
+- **Snowpark Python:** use fsspec / `create_filesystem` in Snowpark notebooks to read AltaStata paths with the same account credentials.
+
+---
+
+## S3-compatible API (boto3, aws CLI, s3fs)
+
+```python
+f = AltaStataFunctions.from_account_dir("/path/to/account", transport="grpc", password="secret")
+
+s3 = f.boto3_s3()   # pip install boto3
+s3.put_object(Bucket="altastata-bucket", Key="hello.txt", Body=b"hi")
+
+f.install_aws_env()   # AWS_* for !aws s3 ls in Jupyter
+```
+
+---
+
+## PyTorch & TensorFlow
+
+```python
+from altastata import AltaStataFunctions, AltaStataPyTorchDataset
+from altastata.altastata_pytorch_dataset import register_altastata_functions_for_pytorch
+
+f = AltaStataFunctions.from_account_dir("/path/to/account", transport="grpc", password="secret")
+register_altastata_functions_for_pytorch(f, "my_account")
+dataset = AltaStataPyTorchDataset("my_account", root_dir="Public/", file_pattern="*.jpg")
+```
+
+See `examples/pytorch-example/` and `examples/tensorflow-example/`.
+
+---
+
+## Event notifications
+
+```python
+def on_event(name, data):
+    print(name, data)
+
+f = AltaStataFunctions.from_account_dir("/path/to/account", enable_callback_server=True)
+f.set_password("secret")
+f.add_event_listener(on_event)
+```
+
+With gRPC / Web UI, SHARE and DELETE events also appear in the browser and via `EventsService.Watch`.
+
+See `examples/event-listener-example/`.
+
+---
+
+## Docker Jupyter (optional)
+
+```bash
+cd containers/jupyter
+docker compose -f docker-compose.yml -f docker-compose-ghcr.yml up -d
+```
+
+- JupyterLab: http://127.0.0.1:8888  
+- **Web UI** / gRPC: http://127.0.0.1:9877  
+
+Images: `ghcr.io/sergevil/altastata/jupyter-datascience-{arm64,amd64}:latest`
+
+---
+
+## Web UI (AltaStata Console)
+
+The wheel ships a browser file manager. Start the gateway:
 
 ```bash
 altastata-grpc-server
-# or (same entry point via Python module):
-python -m altastata.grpc_server
+# same as: python -m altastata.grpc_server
 ```
 
-The launcher binds gRPC to `127.0.0.1:9877` and, when the wheel ships with a
-bundled AltaStata Console SPA at `altastata/lib/altastata-console-static/`,
-serves the SPA from the same port. Open <http://127.0.0.1:9877> in a browser
-to get a Finder-style file manager with auto-refresh on `SHARE` / `DELETE`
-events from other users (see `mycloud/altastata-grpc/EventsService` and
-`altastata-console`). The launcher exports `ALTASTATA_WEB_UI_DIR`
-automatically; set `ALTASTATA_WEB_UI_DIR=` to disable the UI and keep the
-port gRPC-only.
+Open **http://127.0.0.1:9877** — Miller-column browser, upload/download, share, generate keys, and live refresh on SHARE/DELETE events.
 
-## PyTorch & TensorFlow Integration
+**Sign in:** Settings → **Choose account folder** → **Sign in**
 
-```python
-# Register the altastata functions for PyTorch or TensorFlow as a custom dataset
-register_altastata_functions_for_pytorch(altastata_functions, "my_account")
-register_altastata_functions_for_tensorflow(altastata_functions, "my_account")
+| Account type | Password in Settings |
+|--------------|-------------------|
+| RSA / PQC | Your account password |
+| HPCS / HSM | Leave blank |
 
-# For PyTorch application use
-torch_dataset = AltaStataPyTorchDataset(
-    "my_account",
-    root_dir=root_dir,
-    file_pattern=pattern,
-    transform=transform
-)
+Set `ALTASTATA_WEB_UI_DIR=` (empty) to disable the UI and run gRPC-only.
 
-# For TensorFlow application use
-tensorflow_dataset = AltaStataTensorFlowDataset(
-    "my_account",
-    root_dir=root_dir,
-    file_pattern=pattern,
-    preprocess_fn=preprocess_fn
-)
-```
+---
 
-## fsspec Integration
+## More documentation
 
-Altastata implements the fsspec interface, making it compatible with any Python library that uses standard file operations:
+- **Developers** (build wheel, bundle JAR + Console SPA, PyPI): [`README-developer.md`](README-developer.md)
+- **Examples**: [`examples/`](examples/)
 
-```python
-from altastata import AltaStataFunctions
-from altastata.fsspec import create_filesystem
+## Questions?
 
-# Create AltaStata connection
-altastata_functions = AltaStataFunctions.from_account_dir('/path/to/account')
-altastata_functions.set_password("your_password")
+Email [contact@altastata.com](mailto:contact@altastata.com).
 
-# Create fsspec filesystem
-fs = create_filesystem(altastata_functions, "my_account")
+## License
 
-# Use it like any Python file system
-files = fs.ls("Public/")
-with fs.open("Public/Documents/file.txt", "r") as f:
-    content = f.read()
-    print(content)
-```
-
-This means you can use Altastata with pandas, dask, xarray, and hundreds of other libraries without any special configuration.
-
-## boto3 / `aws` CLI / `s3fs` (S3-compatible API)
-
-The bundled `altastata-services` JVM exposes an S3-compatible REST API on
-port `9876` from inside the **same process** that backs the Python API,
-so `boto3` and the Python API see the same files. Three helpers on
-`AltaStataFunctions` drive the admin bootstrap and surface the
-access/secret pair the gateway generates:
-
-```python
-from altastata import AltaStataFunctions
-
-alt = AltaStataFunctions.from_account_dir("/path/to/account")
-alt.set_password("your_password")
-
-# One-liner: ready-to-use boto3 S3 client.
-s3 = alt.boto3_s3()
-print(s3.list_buckets())
-# `altastata-bucket` is the virtual bucket the gateway exposes for this
-# account; substitute your own name if your deployment uses a different one.
-s3.put_object(Bucket="altastata-bucket", Key="hello.txt", Body=b"hi")
-
-# Or: just the kwargs — pass to any AWS SDK / s3fs / pyarrow / awswrangler.
-creds = alt.s3_credentials()
-# {'endpoint_url': 'http://127.0.0.1:9876',
-#  'aws_access_key_id': 'AKIA...',
-#  'aws_secret_access_key': '...',
-#  'region_name': 'us-east-1'}
-
-import s3fs
-fs = s3fs.S3FileSystem(
-    key=creds["aws_access_key_id"],
-    secret=creds["aws_secret_access_key"],
-    client_kwargs={"endpoint_url": creds["endpoint_url"]},
-)
-
-# Or: install AWS_* env vars so `!aws s3 ls`, `!s3cmd ls`, and any SDK
-# that reads the ambient environment all "just work" — handy from Jupyter
-# notebook shell cells.
-alt.install_aws_env()
-```
-
-Requirements:
-
-- The S3 gateway must be enabled on the JVM
-  (`ALTASTATA_SERVICES_S3GATEWAY_ENABLED=true`, which is the **default in the
-  bundled `jupyter-datascience` docker compose**).
-- `boto3` is **not** in the wheel's `install_requires` — install it
-  separately (`pip install boto3`) only if you want the
-  `alt.boto3_s3()` convenience. `s3_credentials()` and `install_aws_env()`
-  use stdlib only.
-
-## Event Listener
-
-Get real-time notifications when file operations occur:
-
-```python
-from altastata import AltaStataFunctions
-
-# Event handler
-def event_handler(event_name, data):
-    print(f"📢 Event: {event_name}, Data: {data}")
-    if event_name == "SHARE":
-        print("File was shared!")
-    elif event_name == "DELETE":
-        print("File was deleted!")
-
-# Initialize with callback server
-altastata = AltaStataFunctions.from_account_dir(
-    '/path/to/account',
-    enable_callback_server=True,
-    callback_server_port=25334
-)
-altastata.set_password("your_password")
-
-# Register listener
-listener = altastata.add_event_listener(event_handler)
-
-# Events will now be delivered in real-time!
-# See examples/event-listener-example/ for complete demos
-```
-
-**Perfect for:**
-- Data sharing among the users
-- Audit logging and compliance
-- Workflow automation
-
-See [`examples/event-listener-example/`](examples/event-listener-example/) for complete documentation and working examples.
-
-## LangChain Integration
-
-Use Altastata as a document source for LangChain applications:
-
-```python
-from langchain.document_loaders import DirectoryLoader
-from altastata.fsspec import create_filesystem
-from altastata import AltaStataFunctions
-
-# Create AltaStata connection
-altastata_functions = AltaStataFunctions.from_account_dir('/path/to/account')
-altastata_functions.set_password("your_password")
-
-# Create fsspec filesystem
-fs = create_filesystem(altastata_functions, "my_account")
-
-# Use with LangChain document loaders
-loader = DirectoryLoader("Public/Documents/", filesystem=fs)
-documents = loader.load()
-
-# Use with vector stores
-from langchain.vectorstores import FAISS
-from langchain.embeddings import OpenAIEmbeddings
-
-vectorstore = FAISS.from_documents(documents, OpenAIEmbeddings())
-```
-
-**Perfect for:**
-- RAG (Retrieval-Augmented Generation) applications
-- Document processing pipelines
-- Knowledge base construction
-- Multi-modal AI applications
-
-See the [full documentation](https://github.com/sergevil/altastata-python-package) for more examples and advanced usage.
-
-This project is licensed under the MIT License. 
+MIT License — see [LICENSE](LICENSE).

--- a/altastata/base_gateway.py
+++ b/altastata/base_gateway.py
@@ -7,6 +7,8 @@ from py4j.java_gateway import JavaGateway, GatewayParameters, CallbackServerPara
 from threading import Thread
 import platform
 
+from altastata.java_runtime import resolve_java_memory_opts
+
 class BaseGateway:
     def __init__(self, port=25333, enable_callback_server=True, callback_server_port=None):
         self.port = port
@@ -101,13 +103,11 @@ class BaseGateway:
         java_command = [
             'java',
             '--add-opens', 'java.base/java.util=ALL-UNNAMED',
-            '-Xms1g',                    # Initial heap size
-            '-Xmx4g',                    # Max heap size
+            *resolve_java_memory_opts(),
             #'-XX:+UseZGC',               # Use ZGC for very low pause times - !!! crashes on IBM Z and LinuxONE !!!
             '-XX:+UnlockExperimentalVMOptions',
             '-XX:+UseStringDeduplication', # Reduce memory usage for strings
             '-Xlog:gc*:file=gc.log:time,uptime:filecount=5,filesize=10M', # GC logging
-            '-XX:ThreadStackSize=256k',  # Reduce thread stack size
             '-XX:+DisableExplicitGC',    # Prevent explicit GC calls
             '-cp', classpath,
             'py4j.GatewayServer',

--- a/altastata/grpc_client.py
+++ b/altastata/grpc_client.py
@@ -14,6 +14,8 @@ import uuid
 import pkg_resources
 import platform
 
+from altastata.java_runtime import resolve_java_memory_opts
+
 
 def _default_client_hint() -> str:
     """
@@ -875,7 +877,7 @@ def _resolve_local_grpc_startup_command(
         if bundled_uber_jar is not None:
             classpath = _build_bundled_grpc_classpath(bundled_uber_jar)
             main_class = _grpc_main_class_for_jar(bundled_uber_jar)
-            grpc_server_command = ["java", "-cp", classpath, main_class]
+            grpc_server_command = ["java", *resolve_java_memory_opts(), "-cp", classpath, main_class]
             if resolved_working_dir is None:
                 resolved_working_dir = os.path.dirname(bundled_uber_jar)
         else:
@@ -954,7 +956,7 @@ def _build_grpc_subprocess_env() -> Dict[str, str]:
     gRPC gateway from Python.
 
     Inherits the parent environment so callers can keep influencing Java
-    tuning via ``JAVA_OPTS`` and similar, then exports
+    tuning via ``JAVA_TOOL_OPTIONS`` / ``JAVA_OPTS``, then exports
     ``ALTASTATA_WEB_UI_DIR`` pointing at the bundled SPA bundle (when one is
     present in this wheel) so the Java gateway also serves the AltaStata
     Console UI on the gRPC port. The variable is set only if the caller has

--- a/altastata/java_runtime.py
+++ b/altastata/java_runtime.py
@@ -1,0 +1,31 @@
+"""Shared JVM heap / thread-stack defaults for embedded AltaStata Java runtimes."""
+
+import os
+from typing import List
+
+# Keep in sync with altastata-services/build.gradle and altastata-services Dockerfiles.
+# Rule of thumb: container RAM >= Xmx + ~1.5 GiB for OpsExecutors thread stacks.
+DEFAULT_JAVA_MEMORY_OPTS = [
+    "-Xms1g",
+    "-Xmx4g",
+    "-XX:ThreadStackSize=256k",
+]
+
+
+def resolve_java_memory_opts() -> List[str]:
+    """Heap/stack flags to pass on the ``java`` command line.
+
+    Local ``pip install`` runs usually have no Java tuning env, so embed the
+    defaults on the argv. When ``JAVA_TOOL_OPTIONS`` or ``JAVA_OPTS`` already
+    set ``-Xmx`` (typical in Docker compose / k8s), return ``[]`` so the
+    environment is the single source of truth and compose overrides work.
+    """
+    combined = " ".join(
+        (
+            os.environ.get("JAVA_TOOL_OPTIONS", ""),
+            os.environ.get("JAVA_OPTS", ""),
+        )
+    )
+    if "-Xmx" in combined:
+        return []
+    return list(DEFAULT_JAVA_MEMORY_OPTS)

--- a/containers/confidential-gke/jupyter-deployment.yaml
+++ b/containers/confidential-gke/jupyter-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: jupyter-datascience
-        image: ghcr.io/sergevil/altastata/jupyter-datascience-amd64:2026f_latest
+        image: ghcr.io/sergevil/altastata/jupyter-datascience-amd64:2026g_latest
         ports:
         - containerPort: 8888
         env:
@@ -26,13 +26,15 @@ spec:
           value: ""
         - name: JUPYTER_ALLOW_INSECURE_WRITES
           value: "1"
+        - name: JAVA_TOOL_OPTIONS
+          value: "-Xmx4g -Xms1g -XX:ThreadStackSize=256k"
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1"
+            memory: "8Gi"
+            cpu: "500m"
           limits:
-            memory: "4Gi"
-            cpu: "2"
+            memory: "12Gi"
+            cpu: "2000m"
         volumeMounts:
         - name: jupyter-work
           mountPath: /home/jovyan/work

--- a/containers/jupyter/docker-compose-ghcr.yml
+++ b/containers/jupyter/docker-compose-ghcr.yml
@@ -18,6 +18,7 @@ services:
       - JUPYTER_ENABLE_LAB=yes
       - JUPYTER_TOKEN=
       - JUPYTER_ALLOW_INSECURE_WRITES=1
+      - JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS:--Xmx4g -Xms1g -XX:ThreadStackSize=256k}
     networks:
       - altastata-network
     restart: unless-stopped

--- a/containers/jupyter/docker-compose.yml
+++ b/containers/jupyter/docker-compose.yml
@@ -54,6 +54,8 @@ services:
       # passwords or decrypted material — all sensitive bytes are still
       # encrypted by the user password (see S3Controller.getConfigurableFilePath).
       - ALTASTATA_USERDATA_FILE=${ALTASTATA_USERDATA_FILE:-/home/jovyan/work/altastata-userdata.json}
+      # Embedded altastata-services JVM (altastata-grpc-server). Merged with image defaults.
+      - JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS:--Xmx4g -Xms1g -XX:ThreadStackSize=256k}
     networks:
       - altastata-network
     restart: unless-stopped

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='altastata',
-    version='0.1.43',
+    version='0.1.45',
     author='Serge Vilvovsky',
     author_email='serge.vilvovsky@altastata.com',
     description='A Python package for Altastata data processing and machine learning integration',

--- a/tests/test_grpc_client.py
+++ b/tests/test_grpc_client.py
@@ -302,7 +302,15 @@ class GrpcClientTests(unittest.TestCase):
         # env is built by _build_grpc_subprocess_env (covered separately) and
         # is forwarded to Popen so the Java side can pick up the bundled SPA.
         mock_popen.assert_called_once_with(
-            ["java", "-cp", "/tmp/a.jar:/tmp/b.jar:/tmp/altastata-services-1.0.0-uber.jar", "com.altastata.services.AltaStataServicesApplication"],
+            [
+                "java",
+                "-Xms1g",
+                "-Xmx4g",
+                "-XX:ThreadStackSize=256k",
+                "-cp",
+                "/tmp/a.jar:/tmp/b.jar:/tmp/altastata-services-1.0.0-uber.jar",
+                "com.altastata.services.AltaStataServicesApplication",
+            ],
             cwd="/tmp",
             env=unittest.mock.ANY,
             stdout=unittest.mock.ANY,
@@ -397,6 +405,56 @@ class GrpcClientTests(unittest.TestCase):
             ):
                 from altastata.grpc_client import _find_bundled_console_ui_dir
                 self.assertEqual(_find_bundled_console_ui_dir(), os.path.abspath(ui_dir))
+
+    @patch("altastata.grpc_client.subprocess.Popen")
+    @patch("altastata.grpc_client._find_bundled_grpc_uber_jar")
+    @patch("altastata.grpc_client._build_bundled_grpc_classpath")
+    def test_start_local_grpc_service_defers_to_java_tool_options(
+        self,
+        mock_build_cp,
+        mock_find_uber,
+        mock_popen,
+    ):
+        mock_find_uber.return_value = "/tmp/altastata-services-1.0.0-uber.jar"
+        mock_build_cp.return_value = "/tmp/altastata-services-1.0.0-uber.jar"
+        mock_popen.return_value = MagicMock()
+
+        from altastata.grpc_client import _start_local_grpc_service
+        with patch.dict(
+            os.environ,
+            {"JAVA_TOOL_OPTIONS": "-Xmx2g -Xms512m -XX:ThreadStackSize=256k"},
+            clear=False,
+        ):
+            _start_local_grpc_service()
+
+        mock_popen.assert_called_once_with(
+            [
+                "java",
+                "-cp",
+                "/tmp/altastata-services-1.0.0-uber.jar",
+                "com.altastata.services.AltaStataServicesApplication",
+            ],
+            cwd="/tmp",
+            env=unittest.mock.ANY,
+            stdout=unittest.mock.ANY,
+            stderr=unittest.mock.ANY,
+        )
+
+    def test_resolve_java_memory_opts_embeds_defaults_without_env(self):
+        from altastata.java_runtime import DEFAULT_JAVA_MEMORY_OPTS, resolve_java_memory_opts
+
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(resolve_java_memory_opts(), DEFAULT_JAVA_MEMORY_OPTS)
+
+    def test_resolve_java_memory_opts_skips_when_java_tool_options_sets_heap(self):
+        from altastata.java_runtime import resolve_java_memory_opts
+
+        with patch.dict(
+            os.environ,
+            {"JAVA_TOOL_OPTIONS": "-Xmx2g -Xms512m -XX:ThreadStackSize=256k"},
+            clear=True,
+        ):
+            self.assertEqual(resolve_java_memory_opts(), [])
 
 
 if __name__ == "__main__":

--- a/version.sh
+++ b/version.sh
@@ -20,7 +20,7 @@
 # work. Separating the tags keeps each image's history truthful and avoids
 # end-user confusion ("did Jupyter change between 2026e and 2026g?" — no).
 
-JUPYTER_VERSION="2026f_latest"
+JUPYTER_VERSION="2026g_latest"
 RAG_VERSION="2026j_latest"
 
 # Resolve repo root from this script's location so callers can `source version.sh`


### PR DESCRIPTION
## Summary
- Centralize embedded JVM memory defaults in `altastata/java_runtime.py` and reuse them in both Py4J (`base_gateway.py`) and bundled gRPC startup (`grpc_client.py`).
- Defer to `JAVA_TOOL_OPTIONS` / `JAVA_OPTS` when heap flags are already provided, and add tests covering both default-embedding and env-driven behavior.
- Set `JAVA_TOOL_OPTIONS` defaults for Jupyter compose/GKE deployment, bump package/image versions, and refresh `README.md` to document the gRPC-first workflow and integrations.

## Test plan
- [x] `python -m pytest -q tests/test_grpc_client.py`
- [ ] `docker compose -f containers/jupyter/docker-compose.yml -f containers/jupyter/docker-compose-ghcr.yml up -d` and verify gRPC/Web UI startup with default `JAVA_TOOL_OPTIONS`
- [ ] Repeat startup with explicit `JAVA_TOOL_OPTIONS` override and verify command line does not duplicate `-Xmx`
- [ ] Validate account login + simple list/download flow in Web UI (`http://127.0.0.1:9877`) and Python `transport=\"grpc\"`


Made with [Cursor](https://cursor.com)