### PR TITLE
Release altastata 0.0.1: Console UI on by default

### DIFF
--- a/containers/jupyter/Dockerfile.amd64
+++ b/containers/jupyter/Dockerfile.amd64
@@ -90,7 +90,7 @@ ENV JUPYTER_CONFIG_DIR=/home/jovyan/.jupyter
 # port forwarding reaches it. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
 
-# Optional Console UI on :9877. Off by default; set ENABLE_ALTASTATA_CONSOLE_UI=1
+# Console UI on :9877 (default on). Set ENABLE_ALTASTATA_CONSOLE_UI=0 to disable.
 # to auto-start altastata-grpc-server alongside Jupyter Lab.
 USER root
 COPY containers/jupyter/altastata-console-entrypoint.sh \

--- a/containers/jupyter/Dockerfile.arm64
+++ b/containers/jupyter/Dockerfile.arm64
@@ -68,7 +68,7 @@ ENV LC_ALL=en_US.UTF-8
 # port forwarding reaches it. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
 
-# Optional Console UI on :9877. Off by default; set ENABLE_ALTASTATA_CONSOLE_UI=1
+# Console UI on :9877 (default on). Set ENABLE_ALTASTATA_CONSOLE_UI=0 to disable.
 # to auto-start altastata-grpc-server alongside Jupyter Lab.
 USER root
 COPY containers/jupyter/altastata-console-entrypoint.sh \

--- a/containers/jupyter/Dockerfile.s390x
+++ b/containers/jupyter/Dockerfile.s390x
@@ -117,7 +117,7 @@ ENV LC_ALL=en_US.UTF-8
 # port forwarding reaches it. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
 
-# Optional Console UI on :9877. Off by default; set ENABLE_ALTASTATA_CONSOLE_UI=1
+# Console UI on :9877 (default on). Set ENABLE_ALTASTATA_CONSOLE_UI=0 to disable.
 # to auto-start altastata-grpc-server alongside Jupyter Lab.
 USER root
 COPY containers/jupyter/altastata-console-entrypoint.sh \

--- a/containers/jupyter/README-Docker.md
+++ b/containers/jupyter/README-Docker.md
@@ -140,8 +140,8 @@ docker exec altastata-jupyter tail -f /tmp/altastata-grpc-server.log
 #   the same machine — RAG defaults to 9878).
 # - For a plain `docker run` (no compose), pass both:
 #     -p 127.0.0.1:9877:9877 -e ENABLE_ALTASTATA_CONSOLE_UI=1
-#   The image still ships with ENABLE_ALTASTATA_CONSOLE_UI off, so a bare
-#   `docker run` gives you Jupyter only — no JVM, no Console UI.
+#   Console UI is on by default (entrypoint + compose); set
+#   ENABLE_ALTASTATA_CONSOLE_UI=0 to skip the JVM.
 # See mycloud/altastata-grpc/TLS_DESIGN.md (§10).
 ```
 

--- a/containers/jupyter/altastata-console-entrypoint.sh
+++ b/containers/jupyter/altastata-console-entrypoint.sh
@@ -3,7 +3,7 @@
 # ENABLE_ALTASTATA_CONSOLE_UI=1. See mycloud/altastata-grpc/TLS_DESIGN.md.
 set -e
 
-if [ "${ENABLE_ALTASTATA_CONSOLE_UI:-0}" = "1" ]; then
+if [ "${ENABLE_ALTASTATA_CONSOLE_UI:-1}" = "1" ]; then
     altastata-grpc-server > /tmp/altastata-grpc-server.log 2>&1 &
 fi
 

--- a/containers/rag-example/Dockerfile.open_llm_mac
+++ b/containers/rag-example/Dockerfile.open_llm_mac
@@ -49,7 +49,7 @@ ENV LOCAL_INDEX_PATH=/app/open_llm/local_index
 # Use Transformers by default (same as s390x). Override with -e LLM_PROVIDER=ollama if using Ollama on host.
 ENV LLM_PROVIDER=transformers
 
-# Optional Console UI on :9877; off by default (set ENABLE_ALTASTATA_CONSOLE_UI=1).
+# Console UI on :9877 (default on). Set ENABLE_ALTASTATA_CONSOLE_UI=0 to disable.
 # Host-side must use `-p 127.0.0.1:9877:9877`. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
 

--- a/containers/rag-example/Dockerfile.open_llm_s390x
+++ b/containers/rag-example/Dockerfile.open_llm_s390x
@@ -158,7 +158,7 @@ ENV LOCAL_INDEX_PATH=/app/open_llm/local_index
 ENV LLM_PROVIDER=llama-cpp
 ENV LLAMA_CPP_MODEL_DIR=/models
 
-# Optional Console UI on :9877; off by default (set ENABLE_ALTASTATA_CONSOLE_UI=1).
+# Console UI on :9877 (default on). Set ENABLE_ALTASTATA_CONSOLE_UI=0 to disable.
 # Host-side must use `-p 127.0.0.1:9877:9877`. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0
 

--- a/containers/rag-example/build-and-run-rag-mac.sh
+++ b/containers/rag-example/build-and-run-rag-mac.sh
@@ -47,10 +47,10 @@ RUN_OPTS=(
   -v "$ACCOUNT_PARENT:/altastata_account:ro"
   -v "$INDEX_VOLUME:/app/open_llm/local_index"
 )
-# Opt-in Console UI. Host port defaults to 9878 so RAG can co-exist with
+# Console UI on by default. Host port defaults to 9878 so RAG can co-exist with
 # Jupyter (which defaults to 9877). Override with ALTASTATA_CONSOLE_UI_HOST_PORT.
-#   ENABLE_ALTASTATA_CONSOLE_UI=1 ./build-and-run-rag-mac.sh
-if [ "${ENABLE_ALTASTATA_CONSOLE_UI:-0}" = "1" ]; then
+#   ENABLE_ALTASTATA_CONSOLE_UI=0 ./build-and-run-rag-mac.sh  # disable
+if [ "${ENABLE_ALTASTATA_CONSOLE_UI:-1}" = "1" ]; then
   CONSOLE_UI_HOST_PORT="${ALTASTATA_CONSOLE_UI_HOST_PORT:-9878}"
   RUN_OPTS+=(-p "127.0.0.1:${CONSOLE_UI_HOST_PORT}:9877" -e "ENABLE_ALTASTATA_CONSOLE_UI=1")
 fi
@@ -81,7 +81,7 @@ docker run "${RUN_OPTS[@]}" "$IMAGE_NAME"
 echo "Container started. To follow logs: docker logs -f $CONTAINER_NAME"
 
 echo "Done. Open http://localhost:$WEB_PORT/"
-if [ "${ENABLE_ALTASTATA_CONSOLE_UI:-0}" = "1" ]; then
+if [ "${ENABLE_ALTASTATA_CONSOLE_UI:-1}" = "1" ]; then
   echo "AltaStata Console UI: http://127.0.0.1:${CONSOLE_UI_HOST_PORT}/  (only reachable from this machine; bound to host loopback)"
 fi
 echo "Index is in volume $INDEX_VOLUME (persists across restarts). Wait 1–2 min on first run for indexer + server startup, then query."

--- a/containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
+++ b/containers/rag-example/pull-and-run-rag-s390x-from-icr.sh
@@ -89,13 +89,13 @@ LLAMA_OPTS=""
 [ -n "${LLAMA_CPP_N_CTX:-}" ]      && LLAMA_OPTS="$LLAMA_OPTS -e LLAMA_CPP_N_CTX=$LLAMA_CPP_N_CTX"
 [ -n "${LLAMA_CPP_MAX_TOKENS:-}" ] && LLAMA_OPTS="$LLAMA_OPTS -e LLAMA_CPP_MAX_TOKENS=$LLAMA_CPP_MAX_TOKENS"
 
-# Opt-in Console UI. Host port defaults to 9878 so RAG can co-exist with
+# Console UI on by default. Host port defaults to 9878 so RAG can co-exist with
 # Jupyter (which defaults to 9877). Override with ALTASTATA_CONSOLE_UI_HOST_PORT.
 # Bound to host loopback on the server; reach from your laptop via
 # `ssh -L <port>:127.0.0.1:<port> ...`.
 CONSOLE_UI_OPTS=""
 CONSOLE_UI_HOST_PORT="${ALTASTATA_CONSOLE_UI_HOST_PORT:-9878}"
-if [ "${ENABLE_ALTASTATA_CONSOLE_UI:-0}" = "1" ]; then
+if [ "${ENABLE_ALTASTATA_CONSOLE_UI:-1}" = "1" ]; then
   CONSOLE_UI_OPTS="-p 127.0.0.1:${CONSOLE_UI_HOST_PORT}:9877 -e ENABLE_ALTASTATA_CONSOLE_UI=1"
 fi
 
@@ -138,7 +138,7 @@ ssh $SSH_OPTS "$SSH_HOST" "curl -s --max-time $((QUERY_TIMEOUT + 60)) -X POST ht
 echo ""
 echo "Done. Container $CONTAINER_NAME is running on the server (port 8000)."
 echo "Open http://<server-ip>:8000/ or stop: ssh $SSH_OPTS $SSH_HOST 'docker stop $CONTAINER_NAME; docker rm $CONTAINER_NAME'"
-if [ "${ENABLE_ALTASTATA_CONSOLE_UI:-0}" = "1" ]; then
+if [ "${ENABLE_ALTASTATA_CONSOLE_UI:-1}" = "1" ]; then
   echo "AltaStata Console UI is bound to 127.0.0.1:${CONSOLE_UI_HOST_PORT} on $SSH_HOST."
   echo "Reach it from your laptop with an SSH tunnel:"
   echo "  ssh $SSH_OPTS -L ${CONSOLE_UI_HOST_PORT}:127.0.0.1:${CONSOLE_UI_HOST_PORT} $SSH_HOST"

--- a/examples/rag-example/open_llm/Dockerfile
+++ b/examples/rag-example/open_llm/Dockerfile
@@ -38,7 +38,7 @@ ENV PYTHONPATH=/app/open_llm
 ENV VECTOR_STORE=simple
 ENV LOCAL_INDEX_PATH=/app/open_llm/local_index
 
-# Optional Console UI on :9877; off by default (set ENABLE_ALTASTATA_CONSOLE_UI=1).
+# Console UI on :9877 (default on). Set ENABLE_ALTASTATA_CONSOLE_UI=0 to disable.
 # 0.0.0.0 lets Docker's port forwarder reach the gateway; host-side mapping
 # bounds exposure. See mycloud/altastata-grpc/TLS_DESIGN.md.
 ENV ALTASTATA_GRPC_BIND_ADDRESS=0.0.0.0

--- a/examples/rag-example/open_llm/docker-compose.yml
+++ b/examples/rag-example/open_llm/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - ALTASTATA_PASSWORD=${ALTASTATA_PASSWORD:-123}
       - ALTASTATA_ACCOUNT_ID=${ALTASTATA_ACCOUNT_ID:-bob123}
       # Set to 1 in .env to auto-start Console UI on :9877 alongside RAG.
-      - ENABLE_ALTASTATA_CONSOLE_UI=${ENABLE_ALTASTATA_CONSOLE_UI:-0}
+      - ENABLE_ALTASTATA_CONSOLE_UI=${ENABLE_ALTASTATA_CONSOLE_UI:-1}
     volumes:
       - ${ALTASTATA_ACCOUNT_DIR:-/tmp/altastata-account-must-set-in-env}:/altastata_account:ro
       - local_index_data:/app/open_llm/local_index

--- a/examples/rag-example/open_llm/docker-entrypoint.sh
+++ b/examples/rag-example/open_llm/docker-entrypoint.sh
@@ -56,7 +56,7 @@ if [ -n "$ALTASTATA_ACCOUNT_DIR" ] && [ -d "$ALTASTATA_ACCOUNT_DIR" ]; then
 fi
 
 # Optional Console UI on :9877. See mycloud/altastata-grpc/TLS_DESIGN.md.
-if [ "${ENABLE_ALTASTATA_CONSOLE_UI:-0}" = "1" ]; then
+if [ "${ENABLE_ALTASTATA_CONSOLE_UI:-1}" = "1" ]; then
   if [ -n "$ALTASTATA_ACCOUNT_DIR" ] && [ -d "$ALTASTATA_ACCOUNT_DIR" ]; then
     echo "[entrypoint] Starting altastata-grpc-server on :9877."
     altastata-grpc-server > /tmp/altastata-grpc-server.log 2>&1 &

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='altastata',
-    version='0.1.45',
+    version='0.0.1',
     author='Serge Vilvovsky',
     author_email='serge.vilvovsky@altastata.com',
     description='A Python package for Altastata data processing and machine learning integration',


### PR DESCRIPTION
## Summary
- Reset PyPI package version to **0.0.1** after clearing legacy releases (0.0.1 wheel/sdist published; Docker images `2026g_latest` pushed to GHCR for arm64 and amd64).
- Enable **AltaStata Console UI by default** across Jupyter and RAG Docker stacks (`ENABLE_ALTASTATA_CONSOLE_UI` defaults to `1` in entrypoint, compose, and helper scripts).

## Test plan
- [x] `pip install altastata==0.0.1` from PyPI
- [x] Jupyter arm64 container: PyTorch training ~55s with `transport="grpc"`
- [x] Console UI reachable at http://127.0.0.1:9877/
- [x] GHCR images pushed: `jupyter-datascience-arm64:2026g_latest`, `jupyter-datascience-amd64:2026g_latest`


Made with [Cursor](https://cursor.com)