### PR TITLE
Release altastata 0.0.5: console streaming transfers and Jupyter 2026i_latest

### DIFF
--- a/altastata-console/frontend/package-lock.json
+++ b/altastata-console/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "altastata-console-frontend",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "altastata-console-frontend",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",

--- a/altastata-console/frontend/package.json
+++ b/altastata-console/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altastata-console-frontend",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/altastata-console/frontend/src/App.tsx
+++ b/altastata-console/frontend/src/App.tsx
@@ -30,7 +30,6 @@ import {
   getAccount,
   hasSessionAccountMaterial,
   loadAccountFolderFromPicker,
-  loginWithCurrentSettings,
   subscribeToAltaStataEvents,
 } from "@/api/altastata";
 import { getSessionAccountMaterial } from "@/session/accountMaterial";
@@ -248,21 +247,6 @@ export default function App() {
     return saved;
   };
 
-  const handleSave = async () => {
-    setSettingsBusy(true);
-    setSettingsError(null);
-    setSettingsStatus(null);
-    try {
-      const saved = await persistAndRefresh();
-      setSettingsDraft(saved);
-      setSettingsStatus("Settings saved.");
-    } catch (e) {
-      setSettingsError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setSettingsBusy(false);
-    }
-  };
-
   const handleSaveAndSignIn = async () => {
     setSettingsBusy(true);
     setSettingsError(null);
@@ -274,24 +258,6 @@ export default function App() {
         throw new Error("Choose an account folder before signing in.");
       }
       await bootstrapCurrentSettings();
-      setSettingsStatus("Signed in.");
-      handleRefresh();
-    } catch (e) {
-      setSettingsError(e instanceof Error ? e.message : String(e));
-      setSettingsStatus(null);
-    } finally {
-      setSettingsBusy(false);
-    }
-  };
-
-  const handleReSignIn = async () => {
-    setSettingsBusy(true);
-    setSettingsError(null);
-    setSettingsStatus("Re-signing in...");
-    try {
-      const saved = await persistAndRefresh();
-      setSettingsDraft(saved);
-      await loginWithCurrentSettings();
       setSettingsStatus("Signed in.");
       handleRefresh();
     } catch (e) {
@@ -500,14 +466,6 @@ export default function App() {
         </DialogContent>
         <DialogActions>
           <Button onClick={closeSettings} disabled={settingsBusy}>Close</Button>
-          <Button onClick={() => void handleSave()} disabled={settingsBusy} variant="outlined">Save</Button>
-          <Button
-            onClick={() => void handleReSignIn()}
-            disabled={settingsBusy || !hasSessionAccountMaterial()}
-            variant="outlined"
-          >
-            Re-sign in
-          </Button>
           <Button onClick={() => void handleSaveAndSignIn()} disabled={settingsBusy} variant="contained">
             Sign in
           </Button>

--- a/altastata-console/frontend/src/api/altastata.ts
+++ b/altastata-console/frontend/src/api/altastata.ts
@@ -133,6 +133,30 @@ message DownloadDirectoryAsZipRequest {
   string cloud_path_prefix = 1;
 }
 message DownloadDirectoryAsZipChunk { bytes data = 1; }
+message BeginUploadRequest {
+  string cloud_path = 1;
+  int64 total_size = 2;
+}
+message BeginUploadResponse {
+  string upload_id = 1;
+  int32 chunk_size = 2;
+}
+message UploadChunkRequest {
+  string upload_id = 1;
+  int64 offset = 2;
+  bytes data = 3;
+}
+message UploadChunkResponse {
+  int64 bytes_received = 1;
+}
+message CompleteUploadRequest {
+  string upload_id = 1;
+}
+message CompleteUploadResponse { FileStatus status = 1; }
+message AbortUploadRequest {
+  string upload_id = 1;
+}
+message AbortUploadResponse { bool aborted = 1; }
 message WatchRequest {
   uint64 since_sequence = 1;
 }
@@ -193,6 +217,8 @@ const typeCache = new Map<string, Type>();
 const REQUEST_TIMEOUT_MS = 15_000;
 /** CreateFile waits on encrypted cloud I/O; under bulk folder upload (×4 concurrency) 15s is too short. */
 const UPLOAD_REQUEST_TIMEOUT_MS = 120_000;
+const STREAM_UPLOAD_THRESHOLD_BYTES = 8 * 1024 * 1024;
+const STREAM_UPLOAD_CHUNK_FALLBACK_BYTES = 8 * 1024 * 1024;
 /** Delete with includingSubdirectories walks encrypted metadata; large trees need minutes, not seconds. */
 const DELETE_REQUEST_TIMEOUT_MS = 300_000;
 const LIST_DIR_FAST_TIMEOUT_MS = 5_000;
@@ -1383,6 +1409,96 @@ export async function uploadFile(targetPath: string, content: Uint8Array): Promi
   }
 }
 
+function resolveUploadChunkSize(serverChunkSize: unknown): number {
+  const n = typeof serverChunkSize === "number" ? serverChunkSize : Number(serverChunkSize);
+  if (!Number.isFinite(n) || n <= 0) return STREAM_UPLOAD_CHUNK_FALLBACK_BYTES;
+  return Math.max(256 * 1024, Math.min(16 * 1024 * 1024, Math.floor(n)));
+}
+
+/**
+ * Browser-friendly upload that avoids reading the whole file into memory.
+ * Small files keep the single-RPC CreateFile fast path; large files stream
+ * through BeginUpload/UploadChunk/CompleteUpload with bounded chunk buffers.
+ */
+export async function uploadBrowserFile(
+  targetPath: string,
+  file: File,
+  onProgress?: (bytesSent: number, totalBytes: number) => void,
+): Promise<void> {
+  const totalBytes = file.size || 0;
+  onProgress?.(0, totalBytes);
+  if (totalBytes <= STREAM_UPLOAD_THRESHOLD_BYTES) {
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    await uploadFile(targetPath, bytes);
+    onProgress?.(bytes.length, totalBytes);
+    return;
+  }
+
+  await maybeBootstrap();
+  const cloudPath = toCloudPath(targetPath);
+  let uploadId = "";
+  try {
+    const begin = await withBootstrapRetry(() => grpcUnary(
+      "altastata.v1.FileOpsService/BeginUpload",
+      "BeginUploadRequest",
+      { cloudPath, totalSize: totalBytes },
+      "BeginUploadResponse",
+      true,
+      UPLOAD_REQUEST_TIMEOUT_MS,
+    ));
+    uploadId = typeof begin.uploadId === "string" ? begin.uploadId : "";
+    if (!uploadId) {
+      throw new Error("BeginUpload response missing upload_id");
+    }
+    const chunkSize = resolveUploadChunkSize(begin.chunkSize);
+
+    let offset = 0;
+    while (offset < totalBytes) {
+      const end = Math.min(offset + chunkSize, totalBytes);
+      const chunk = new Uint8Array(await file.slice(offset, end).arrayBuffer());
+      await withBootstrapRetry(() => grpcUnary(
+        "altastata.v1.FileOpsService/UploadChunk",
+        "UploadChunkRequest",
+        { uploadId, offset, data: chunk },
+        "UploadChunkResponse",
+        true,
+        UPLOAD_REQUEST_TIMEOUT_MS,
+      ));
+      offset = end;
+      onProgress?.(offset, totalBytes);
+    }
+
+    const complete = await withBootstrapRetry(() => grpcUnary(
+      "altastata.v1.FileOpsService/CompleteUpload",
+      "CompleteUploadRequest",
+      { uploadId },
+      "CompleteUploadResponse",
+      true,
+      UPLOAD_REQUEST_TIMEOUT_MS,
+    ));
+    const status = complete.status as { error?: string } | undefined;
+    if (status?.error) {
+      throw new Error(status.error);
+    }
+  } catch (error) {
+    if (uploadId) {
+      try {
+        await grpcUnary(
+          "altastata.v1.FileOpsService/AbortUpload",
+          "AbortUploadRequest",
+          { uploadId },
+          "AbortUploadResponse",
+          true,
+          UPLOAD_REQUEST_TIMEOUT_MS,
+        );
+      } catch {
+        // Best effort cleanup; report original failure.
+      }
+    }
+    throw authHint(error);
+  }
+}
+
 export async function deletePath(path: string): Promise<void> {
   try {
     await maybeBootstrap();
@@ -1654,6 +1770,47 @@ export async function streamDirectoryZip(
       "DownloadDirectoryAsZipRequest",
       { cloudPathPrefix: cloudPath },
       "DownloadDirectoryAsZipChunk",
+      true,
+      async (msg) => {
+        const data = msg.data;
+        if (data instanceof Uint8Array) {
+          if (data.length > 0) await onChunk(data);
+        } else if (Array.isArray(data)) {
+          const arr = new Uint8Array(data as number[]);
+          if (arr.length > 0) await onChunk(arr);
+        }
+      },
+      {
+        idleTimeoutMs: options.idleTimeoutMs ?? ZIP_STREAM_IDLE_TIMEOUT_MS,
+        signal: options.signal,
+      },
+    ));
+  } catch (error) {
+    throw authHint(error);
+  }
+}
+
+export async function streamFileDownload(
+  path: string,
+  version: string | null,
+  onChunk: (chunk: Uint8Array) => void | Promise<void>,
+  options: StreamDirectoryZipOptions = {},
+): Promise<void> {
+  try {
+    await maybeBootstrap();
+    const cloudPath = toCloudPath(path);
+    const versionedPath = version ? `${cloudPath}✹${version}` : cloudPath;
+    await withBootstrapRetry(() => grpcServerStreamWithCallback(
+      "altastata.v1.FileOpsService/ReadStream",
+      "ReadStreamRequest",
+      {
+        filePath: versionedPath,
+        snapshotTime: 0,
+        startPosition: 0,
+        parallelChunks: 4,
+        chunkSize: 256 * 1024,
+      },
+      "ReadStreamChunk",
       true,
       async (msg) => {
         const data = msg.data;

--- a/altastata-console/frontend/src/components/BottomToolbar.tsx
+++ b/altastata-console/frontend/src/components/BottomToolbar.tsx
@@ -26,9 +26,10 @@ import ShareIcon from "@mui/icons-material/Share";
 import PersonRemoveIcon from "@mui/icons-material/PersonRemove";
 import GridViewIcon from "@mui/icons-material/GridView";
 import { useRef, useState, type ChangeEvent } from "react";
-import { zip } from "fflate";
+import { Zip, ZipPassThrough, zip } from "fflate";
 import {
   deletePath,
+  fetchFilePreviewMetadata,
   downloadFile,
   listKnownUsers,
   makeUniqueArchiveName,
@@ -37,12 +38,14 @@ import {
   runWithConcurrency,
   sharePaths,
   streamDirectoryZip,
+  streamFileDownload,
   suggestMultiZipName,
   suggestedZipFileName,
-  uploadFile,
+  uploadBrowserFile,
 } from "@/api/altastata";
 
-const FOLDER_UPLOAD_CONCURRENCY = 4;
+const FOLDER_UPLOAD_CONCURRENCY_DEFAULT = 4;
+const FOLDER_UPLOAD_CONCURRENCY_MAX_SMALL_FILES = 12;
 import type { FileEntry } from "@/types";
 import type { DeletingTarget } from "@/utils/deletingTargets";
 
@@ -84,6 +87,19 @@ type SavePickerWindow = Window & {
     }>;
   }) => Promise<SaveFileHandle>;
 };
+
+function formatBytes(value: number): string {
+  if (!Number.isFinite(value) || value < 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let n = value;
+  let idx = 0;
+  while (n >= 1024 && idx < units.length - 1) {
+    n /= 1024;
+    idx += 1;
+  }
+  const fixed = n >= 100 || idx === 0 ? 0 : 1;
+  return `${n.toFixed(fixed)} ${units[idx]}`;
+}
 
 export default function BottomToolbar({
   selectedEntries,
@@ -150,6 +166,36 @@ export default function BottomToolbar({
   // Upload always targets a single context: the lone selection or the active dir.
   const uploadAnchor = singleSelection;
 
+  const chooseFolderUploadConcurrency = (files: File[]): number => {
+    if (files.length === 0) return FOLDER_UPLOAD_CONCURRENCY_DEFAULT;
+    // Small-file bursts (hundreds/thousands) are dominated by per-file RPC and
+    // metadata latency, so higher parallelism improves throughput significantly.
+    const maxSize = files.reduce((m, f) => Math.max(m, f.size || 0), 0);
+    const hw = (typeof navigator !== "undefined" && navigator.hardwareConcurrency)
+      ? navigator.hardwareConcurrency
+      : 8;
+    if (files.length >= 500 && maxSize <= 256 * 1024) {
+      return Math.min(FOLDER_UPLOAD_CONCURRENCY_MAX_SMALL_FILES, Math.max(6, hw));
+    }
+    if (files.length >= 100 && maxSize <= 1024 * 1024) {
+      return Math.min(8, Math.max(4, hw));
+    }
+    return FOLDER_UPLOAD_CONCURRENCY_DEFAULT;
+  };
+
+  const enqueuePendingFoldersForTargetPath = (targetPath: string) => {
+    if (!onAddPendingFolder) return;
+    const normalized = targetPath.trim().replace(/\/+/g, "/");
+    const lastSlash = normalized.lastIndexOf("/");
+    if (lastSlash <= 0) return;
+    let parent = normalized.slice(0, lastSlash);
+    while (parent && parent !== "/") {
+      onAddPendingFolder(parent);
+      const idx = parent.lastIndexOf("/");
+      parent = idx <= 0 ? "/" : parent.slice(0, idx);
+    }
+  };
+
   const selectedLabel = selectionCount === 0
     ? `Path: ${activePath}`
     : singleSelection
@@ -183,10 +229,35 @@ export default function BottomToolbar({
     const file = event.target.files?.[0];
     if (!file) return;
     const targetPath = resolveUploadTargetPath(file.name, uploadAnchor, activePath);
-    await runAction("Upload", async () => {
-      const bytes = new Uint8Array(await file.arrayBuffer());
-      await uploadFile(targetPath, bytes);
-    });
+    const totalBytes = file.size || 0;
+    setBusy(true);
+    setStatus(totalBytes > 0 ? `Uploading 0 B / ${formatBytes(totalBytes)}...` : "Uploading 0 B...");
+    try {
+      let lastProgressAt = 0;
+      let hasReportedProgress = false;
+      await uploadBrowserFile(targetPath, file, (bytesSent, totalBytes) => {
+        const now = Date.now();
+        const isFinal = totalBytes > 0 && bytesSent >= totalBytes;
+        if (hasReportedProgress && !isFinal && now - lastProgressAt < 200) return;
+        const progress = totalBytes > 0
+          ? `${formatBytes(bytesSent)} / ${formatBytes(totalBytes)}`
+          : formatBytes(bytesSent);
+        setStatus(`Uploading ${progress}...`);
+        hasReportedProgress = true;
+        lastProgressAt = now;
+      });
+      const doneSuffix = totalBytes > 0 ? ` (${formatBytes(totalBytes)})` : "";
+      setStatus(`Upload done${doneSuffix}`);
+      onRefresh();
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        setStatus("Upload cancelled");
+      } else {
+        setStatus(error instanceof Error ? `Upload failed: ${error.message}` : "Upload failed");
+      }
+    } finally {
+      setBusy(false);
+    }
     event.target.value = "";
   };
 
@@ -200,17 +271,24 @@ export default function BottomToolbar({
     event.target.value = "";
     if (files.length === 0) return;
 
+    const folderUploadConcurrency = chooseFolderUploadConcurrency(files);
     setBusy(true);
     let completed = 0;
-    setStatus(`Uploading folder (0/${files.length}, ×${FOLDER_UPLOAD_CONCURRENCY})...`);
+    setStatus(`Uploading folder (0/${files.length}, ×${folderUploadConcurrency})...`);
     try {
-      await runWithConcurrency(files, FOLDER_UPLOAD_CONCURRENCY, async (file) => {
+      // Show the folder tree immediately while files are still uploading.
+      for (const file of files) {
         const relativePath = file.webkitRelativePath || file.name;
         const targetPath = resolveUploadTargetPath(relativePath, uploadAnchor, activePath);
-        const bytes = new Uint8Array(await file.arrayBuffer());
-        await uploadFile(targetPath, bytes);
+        enqueuePendingFoldersForTargetPath(targetPath);
+      }
+
+      await runWithConcurrency(files, folderUploadConcurrency, async (file) => {
+        const relativePath = file.webkitRelativePath || file.name;
+        const targetPath = resolveUploadTargetPath(relativePath, uploadAnchor, activePath);
+        await uploadBrowserFile(targetPath, file);
         completed += 1;
-        setStatus(`Uploading folder (${completed}/${files.length}, ×${FOLDER_UPLOAD_CONCURRENCY})...`);
+        setStatus(`Uploading folder (${completed}/${files.length}, ×${folderUploadConcurrency})...`);
       });
       setStatus(`Folder upload done (${completed}/${files.length})`);
       onRefresh();
@@ -234,9 +312,17 @@ export default function BottomToolbar({
 
   const streamZipToHandle = async (handle: SaveFileHandle, path: string) => {
     const writable = await handle.createWritable();
+    let writtenBytes = 0;
+    let lastProgressAt = 0;
     try {
       await streamDirectoryZip(path, async (chunk) => {
         await writable.write(chunk);
+        writtenBytes += chunk.length;
+        const now = Date.now();
+        if (now - lastProgressAt >= 250) {
+          setStatus(`Downloading ZIP ${formatBytes(writtenBytes)}...`);
+          lastProgressAt = now;
+        }
       });
       await writable.close();
     } catch (error) {
@@ -249,18 +335,32 @@ export default function BottomToolbar({
     }
   };
 
-  const collectZipBlob = async (path: string): Promise<Blob> => {
-    const parts: BlobPart[] = [];
-    await streamDirectoryZip(path, (chunk) => {
-      parts.push(chunk.slice());
-    });
-    return new Blob(parts, { type: "application/zip" });
-  };
-
-  const writeBlobToHandle = async (handle: SaveFileHandle, blob: Blob) => {
+  const streamFileToHandle = async (
+    handle: SaveFileHandle,
+    path: string,
+    version: string | null,
+    totalBytesHint: number | null = null,
+  ) => {
+    const selected = selectedEntries.find((entry) => entry.path === path && entry.version === version) ?? null;
+    const totalBytes = totalBytesHint ?? (
+      typeof selected?.size === "number" && selected.size > 0 ? selected.size : null
+    );
+    let writtenBytes = 0;
+    let lastProgressAt = 0;
     const writable = await handle.createWritable();
     try {
-      await writable.write(await blob.arrayBuffer());
+      await streamFileDownload(path, version, async (chunk) => {
+        await writable.write(chunk);
+        writtenBytes += chunk.length;
+        const now = Date.now();
+        if (now - lastProgressAt >= 250) {
+          const progress = totalBytes
+            ? `${formatBytes(writtenBytes)} / ${formatBytes(totalBytes)}`
+            : formatBytes(writtenBytes);
+          setStatus(`Downloading ${progress}...`);
+          lastProgressAt = now;
+        }
+      });
       await writable.close();
     } catch (error) {
       try {
@@ -270,6 +370,49 @@ export default function BottomToolbar({
       }
       throw error;
     }
+  };
+
+  const collectFileBlobStreaming = async (
+    path: string,
+    version: string | null,
+    totalBytesHint: number | null,
+  ): Promise<Blob> => {
+    const parts: BlobPart[] = [];
+    let writtenBytes = 0;
+    let lastProgressAt = 0;
+    await streamFileDownload(path, version, (chunk) => {
+      parts.push(chunk.slice());
+      writtenBytes += chunk.length;
+      const now = Date.now();
+      if (now - lastProgressAt >= 250) {
+        const progress = totalBytesHint
+          ? `${formatBytes(writtenBytes)} / ${formatBytes(totalBytesHint)}`
+          : formatBytes(writtenBytes);
+        setStatus(`Downloading ${progress}...`);
+        lastProgressAt = now;
+      }
+    });
+    return new Blob(parts, { type: "application/octet-stream" });
+  };
+
+  const resolveSingleFileSizeHint = async (entry: FileEntry): Promise<number | null> => {
+    if (entry.is_dir) return null;
+    if (typeof entry.size === "number" && entry.size > 0) return entry.size;
+    try {
+      const metadata = await fetchFilePreviewMetadata(entry.path, entry.version);
+      if (typeof metadata.size === "number" && metadata.size >= 0) return metadata.size;
+    } catch {
+      // Best effort only for nicer progress display.
+    }
+    return null;
+  };
+
+  const collectZipBlob = async (path: string): Promise<Blob> => {
+    const parts: BlobPart[] = [];
+    await streamDirectoryZip(path, (chunk) => {
+      parts.push(chunk.slice());
+    });
+    return new Blob(parts, { type: "application/zip" });
   };
 
   const downloadSingleWithSavePicker = async (entry: FileEntry) => {
@@ -298,11 +441,17 @@ export default function BottomToolbar({
       }
     }
 
+    const totalBytesHint = entry.is_dir ? null : await resolveSingleFileSizeHint(entry);
+
     if (!saveHandle) {
       await runAction("Download", async () => {
         const blob = entry.is_dir
           ? await collectZipBlob(entry.path)
-          : await downloadFile(entry.path, entry.version);
+          : await collectFileBlobStreaming(
+            entry.path,
+            entry.version,
+            totalBytesHint,
+          );
         const url = URL.createObjectURL(blob);
         try {
           startBrowserDownload(url, downloadName);
@@ -318,8 +467,7 @@ export default function BottomToolbar({
         await streamZipToHandle(saveHandle as SaveFileHandle, entry.path);
         return;
       }
-      const blob = await downloadFile(entry.path, entry.version);
-      await writeBlobToHandle(saveHandle as SaveFileHandle, blob);
+      await streamFileToHandle(saveHandle as SaveFileHandle, entry.path, entry.version, totalBytesHint);
     });
   };
 
@@ -335,6 +483,108 @@ export default function BottomToolbar({
       // Default level (6); covers text well, only mild slowdown on already-compressed media.
       zip(files, (err, data) => (err ? reject(err) : resolve(data)));
     });
+  };
+
+  const streamMultiZipToHandle = async (
+    handle: SaveFileHandle,
+    entries: FileEntry[],
+    archiveName: string,
+  ): Promise<void> => {
+    const writable = await handle.createWritable();
+    let settled = false;
+    let totalZipBytes = 0;
+    let lastProgressAt = 0;
+    const totalEntries = entries.length;
+    let processedEntries = 0;
+    let writeChain: Promise<void> = Promise.resolve();
+
+    const rejectOnce = (reject: (reason?: unknown) => void, reason: unknown) => {
+      if (settled) return;
+      settled = true;
+      reject(reason);
+    };
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const zipper = new Zip((err, data, final) => {
+          if (err) {
+            rejectOnce(reject, err);
+            return;
+          }
+          if (settled) return;
+          if (data.length > 0) {
+            writeChain = writeChain
+              .then(async () => {
+                await writable.write(data);
+                totalZipBytes += data.length;
+                const now = Date.now();
+                if (now - lastProgressAt >= 250) {
+                  setStatus(
+                    `Writing ZIP ${formatBytes(totalZipBytes)} `
+                    + `(${processedEntries}/${totalEntries})...`,
+                  );
+                  lastProgressAt = now;
+                }
+              })
+              .catch((error) => {
+                rejectOnce(reject, error);
+              });
+          }
+          if (final) {
+            writeChain
+              .then(() => {
+                if (settled) return;
+                settled = true;
+                resolve();
+              })
+              .catch((error) => {
+                rejectOnce(reject, error);
+              });
+          }
+        });
+
+        void (async () => {
+          try {
+            const used = new Set<string>();
+            for (let i = 0; i < entries.length; i += 1) {
+              const entry = entries[i];
+              const baseName = entry.is_dir ? suggestedZipFileName(entry.path) : entry.name;
+              const uniqueName = makeUniqueArchiveName(baseName, used);
+              setStatus(`Preparing ZIP ${i + 1}/${totalEntries}: ${uniqueName}...`);
+              const zipEntry = new ZipPassThrough(uniqueName);
+              zipper.add(zipEntry);
+              if (entry.is_dir) {
+                await streamDirectoryZip(entry.path, (chunk) => {
+                  zipEntry.push(chunk, false);
+                });
+              } else {
+                await streamFileDownload(entry.path, entry.version, (chunk) => {
+                  zipEntry.push(chunk, false);
+                });
+              }
+              zipEntry.push(new Uint8Array(0), true);
+              processedEntries += 1;
+              setStatus(`Preparing ZIP (${processedEntries}/${totalEntries})...`);
+            }
+            zipper.end();
+          } catch (error) {
+            rejectOnce(reject, error);
+          }
+        })();
+      });
+      await writable.close();
+      setStatus(
+        `Download done (${processedEntries}/${totalEntries} packed into ${archiveName}, `
+        + `${formatBytes(totalZipBytes)})`,
+      );
+    } catch (error) {
+      try {
+        await writable.abort();
+      } catch {
+        // Ignore abort errors if writer is already closed.
+      }
+      throw error;
+    }
   };
 
   const handleDownloadMultiAsZip = async (entries: FileEntry[]) => {
@@ -364,6 +614,12 @@ export default function BottomToolbar({
     let collected = 0;
     setStatus(`Preparing ZIP (0/${total})...`);
     try {
+      if (saveHandle) {
+        await streamMultiZipToHandle(saveHandle, entries, archiveName);
+        onRefresh();
+        return;
+      }
+
       const archive: Record<string, Uint8Array> = {};
       const used = new Set<string>();
       for (const entry of entries) {
@@ -379,15 +635,11 @@ export default function BottomToolbar({
       // current `BlobPart` typings reject; the cast is purely a typing nudge.
       const zipBlob = new Blob([zipped as unknown as BlobPart], { type: "application/zip" });
 
-      if (saveHandle) {
-        await writeBlobToHandle(saveHandle, zipBlob);
-      } else {
-        const url = URL.createObjectURL(zipBlob);
-        try {
-          startBrowserDownload(url, archiveName);
-        } finally {
-          URL.revokeObjectURL(url);
-        }
+      const url = URL.createObjectURL(zipBlob);
+      try {
+        startBrowserDownload(url, archiveName);
+      } finally {
+        URL.revokeObjectURL(url);
       }
       setStatus(`Download done (${collected}/${total} packed into ${archiveName})`);
       onRefresh();
@@ -423,11 +675,17 @@ export default function BottomToolbar({
     const label = selectionCount === 1 ? "Delete" : `Delete ${selectionCount} items`;
     onMarkPathsDeleting?.(deletingMarks);
     setBusy(true);
+    const refreshTimer = window.setInterval(() => {
+      onRefresh();
+    }, 2500);
     try {
       for (let i = 0; i < targets.length; i += 1) {
         const entry = targets[i];
         const mark: DeletingTarget = { path: entry.path, recursive: entry.is_dir };
-        setStatus(`${label} ${i + 1}/${targets.length}: ${entry.path}`);
+        const statusLabel = entry.is_dir
+          ? `Deleting folder${targets.length > 1 ? ` ${i + 1}/${targets.length}` : ""}: ${entry.path}…`
+          : `${label} ${i + 1}/${targets.length}: ${entry.path}`;
+        setStatus(statusLabel);
         await deletePath(entry.path);
         onUnmarkPathsDeleting?.([mark]);
       }
@@ -441,6 +699,7 @@ export default function BottomToolbar({
       }
       setStatus(error instanceof Error ? `${label} failed: ${error.message}` : `${label} failed`);
     } finally {
+      window.clearInterval(refreshTimer);
       setBusy(false);
     }
   };

--- a/altastata-console/frontend/src/components/MillerColumns.tsx
+++ b/altastata-console/frontend/src/components/MillerColumns.tsx
@@ -1,10 +1,10 @@
-import { Fragment, useCallback, useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { Box, Button, Stack, Typography } from "@mui/material";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { isUserNotInitializedError, listDir } from "@/api/altastata";
 import type { FileEntry } from "@/types";
-import type { DeletingTarget } from "@/utils/deletingTargets";
+import { type DeletingTarget } from "@/utils/deletingTargets";
 import FileColumn from "./FileColumn";
 import PreviewPane from "./PreviewPane";
 
@@ -136,6 +136,11 @@ export default function MillerColumns({
     if (additions.length === 0) return column;
     return { ...column, entries: sortEntries([...column.entries, ...additions]) };
   }, [pendingChildrenOf, sortEntries]);
+
+  const displayColumns = useMemo(
+    () => columns.map((col) => mergePendingFolders(col)),
+    [columns, mergePendingFolders],
+  );
 
   const loadColumn = useCallback(async (path: string): Promise<ColumnState> => {
     const data = await listDir(path);
@@ -450,12 +455,12 @@ export default function MillerColumns({
           autoSaveId="altastata-console-miller"
           dir="ltr"
         >
-          {columns.map((col, idx) => (
+          {displayColumns.map((col, idx) => (
             <Fragment key={`${idx}-${col.path}`}>
               <Panel
                 id={`miller-col-${col.path}`}
                 order={idx}
-                defaultSize={getColumnDefaultSize(columns.length)}
+                defaultSize={getColumnDefaultSize(displayColumns.length)}
                 minSize={12}
               >
                 <FileColumn
@@ -479,7 +484,7 @@ export default function MillerColumns({
           ))}
           <Panel
             id="miller-preview"
-            order={columns.length}
+            order={displayColumns.length}
             defaultSize={38}
             minSize={20}
           >

--- a/altastata-console/frontend/src/utils/deletingTargets.ts
+++ b/altastata-console/frontend/src/utils/deletingTargets.ts
@@ -54,3 +54,13 @@ export function isRecursiveDeleteRoot(entry: FileEntry, targets: DeletingTarget[
   if (!entry.is_dir || !targets) return false;
   return targets.some((target) => target.recursive && target.path === entry.path);
 }
+
+/** Hide rows being deleted (folder + descendants) from Miller columns while delete runs. */
+export function shouldHideEntryWhileDeleting(
+  entry: FileEntry,
+  targets: DeletingTarget[] | undefined,
+): boolean {
+  if (!targets || targets.length === 0) return false;
+  if (isRecursiveDeleteRoot(entry, targets)) return true;
+  return isEntryDeleting(entry, targets);
+}

--- a/containers/confidential-gke/jupyter-deployment.yaml
+++ b/containers/confidential-gke/jupyter-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: jupyter-datascience
-        image: ghcr.io/sergevil/altastata/jupyter-datascience-amd64:2026h_latest
+        image: ghcr.io/sergevil/altastata/jupyter-datascience-amd64:2026i_latest
         ports:
         - containerPort: 8888
         env:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='altastata',
-    version='0.0.4',
+    version='0.0.5',
     author='Serge Vilvovsky',
     author_email='serge.vilvovsky@altastata.com',
     description='A Python package for Altastata data processing and machine learning integration',

--- a/version.sh
+++ b/version.sh
@@ -20,7 +20,7 @@
 # work. Separating the tags keeps each image's history truthful and avoids
 # end-user confusion ("did Jupyter change between 2026e and 2026g?" — no).
 
-JUPYTER_VERSION="2026h_latest"
+JUPYTER_VERSION="2026i_latest"
 RAG_VERSION="2026k_latest"
 
 # Resolve repo root from this script's location so callers can `source version.sh`


### PR DESCRIPTION
## Summary
- Stream large file uploads via `BeginUpload`/`UploadChunk` and large downloads via `ReadStream` to avoid browser OOM.
- Show byte progress for single-file upload/download; stream multi-select ZIP to Save As without holding the full archive in RAM.
- Improve delete UX: deleting icons, periodic refresh, folder stays visible until cloud list catches up.
- Remove redundant Settings Save/Re-sign in buttons.
- Bump package to **0.0.5**, console bundle **0.2.3**, Jupyter image tag **2026i_latest**.

## Published artifacts
- PyPI: https://pypi.org/project/altastata/0.0.5/
- GHCR: `ghcr.io/sergevil/altastata/jupyter-datascience-arm64:2026i_latest`
- GHCR: `ghcr.io/sergevil/altastata/jupyter-datascience-amd64:2026i_latest`

## Test plan
- [x] `python -m pytest tests/ -q` (52 passed, 1 skipped)
- [x] `npm run typecheck` in `altastata-console/frontend`
- [ ] Single large file upload shows `Uploading X / Y...`
- [ ] Single large file download shows byte progress
- [ ] Multi-select download with Save As on large files (no browser crash)
- [ ] Bulk folder delete UX (icons + refresh, no premature folder hide)


Made with [Cursor](https://cursor.com)